### PR TITLE
Add a bunch of functionality

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,6 @@ jobs:
             source venv/bin/activate
             pip install -r dev-requirements.txt
             pip install -e .
-            pip install git+https://github.com/jupyter/repo2docker.git@master
             git config --global user.email "ci@circleci"
             git config --global user.name "ci"
 

--- a/hubploy/__main__.py
+++ b/hubploy/__main__.py
@@ -1,0 +1,58 @@
+import argparse
+from hubploy import imagebuilder, helm
+import docker
+
+
+def main():
+    argparser = argparse.ArgumentParser()
+    subparsers = argparser.add_subparsers(dest='command')
+    build_parser = subparsers.add_parser('build', help='Build an image from given path')
+
+    build_parser.add_argument(
+        'path',
+        help='Path to directory with dockerfile'
+    )
+    build_parser.add_argument(
+        'image_name',
+        help='Name of image (including repository) to build, without tag'
+    )
+    build_parser.add_argument(
+        '--commit-range',
+        help='Trigger image rebuilds only if path has changed in this commit range'
+    )
+    build_parser.add_argument(
+        '--push',
+        action='store_true',
+    )
+    
+    deploy_parser = subparsers.add_parser('deploy', help='Deploy a chart to the given environment')
+
+    deploy_parser.add_argument(
+        'deployment'
+    )
+    deploy_parser.add_argument(
+        'chart'
+    )
+    deploy_parser.add_argument(
+        'environment',
+        choices=['develop', 'staging', 'prod']
+    )
+    deploy_parser.add_argument(
+        '--namespace',
+        default=None
+    )
+    deploy_parser.add_argument(
+        '--set',
+        action='append',
+    )
+    deploy_parser.add_argument(
+        '--version',
+    )
+
+    args = argparser.parse_args()
+
+    if args.command == 'build':
+        client = docker.from_env()
+        imagebuilder.build_if_needed(client, args.path, args.image_name, args.commit_range, args.push)
+    elif args.command == 'deploy':
+        helm.deploy(args.deployment, args.chart, args.environment, args.namespace, args.set, args.version)

--- a/hubploy/gitutils.py
+++ b/hubploy/gitutils.py
@@ -14,7 +14,7 @@ def last_modified_commit(*paths, n=1, **kwargs):
         '--pretty=format:%h',
         '--',
         *paths
-    ], **kwargs).decode('utf-8')
+    ], **kwargs).decode('utf-8').split('\n')[-1]
 
 
 def last_modified_date(*paths, **kwargs):

--- a/hubploy/gitutils.py
+++ b/hubploy/gitutils.py
@@ -5,17 +5,42 @@ import subprocess
 import os
 
 
-def last_git_modified(path, n=1):
-    """Get last revision at which `path` got modified"""
-    path = os.path.abspath(path)
-    if os.path.isdir(path):
-        cwd = path
-    else:
-        cwd = os.path.dirname(path)
+def last_modified_commit(*paths, n=1, **kwargs):
+    """Get the last commit to modify the given paths"""
     return subprocess.check_output([
         'git',
         'log',
         '-n', str(n),
         '--pretty=format:%h',
-        path
-    ], cwd=cwd).decode('utf-8').split('\n')[-1]
+        '--',
+        *paths
+    ], **kwargs).decode('utf-8')
+
+
+def last_modified_date(*paths, **kwargs):
+    """Return the last modified date (as a string) for the given paths"""
+    return subprocess.check_output([
+        'git',
+        'log',
+        '-n', '1',
+        '--pretty=format:%cd',
+        '--date=iso',
+        '--',
+        *paths
+    ], **kwargs).decode('utf-8')
+
+
+def path_touched(*paths, commit_range):
+    """Return whether the given paths have been changed in the commit range
+
+    Used to determine if a build is necessary
+
+    Args:
+    *paths (str):
+        paths to check for changes
+    commit_range (str):
+        range of commits to check if paths have changed
+    """
+    return subprocess.check_output([
+        'git', 'diff', '--name-only', commit_range, '--', *paths
+    ]).decode('utf-8').strip() != ''

--- a/hubploy/helm.py
+++ b/hubploy/helm.py
@@ -99,7 +99,7 @@ def deploy(
 
     image_path = os.path.join('deployments', deployment, 'image')
     if os.path.exists(image_path):
-        image_tag = gitutils.last_git_modified(
+        image_tag = gitutils.last_modified_commit(
             os.path.join('deployments', deployment, 'image')
         )
 
@@ -113,35 +113,3 @@ def deploy(
         config_overrides,
         version
     )
-
-
-def main():
-    argparser = argparse.ArgumentParser()
-    argparser.add_argument(
-        'deployment'
-    )
-    argparser.add_argument(
-        'chart'
-    )
-    argparser.add_argument(
-        'environment',
-        choices=['develop', 'staging', 'prod']
-    )
-    argparser.add_argument(
-        '--namespace',
-        default=None
-    )
-    argparser.add_argument(
-        '--set',
-        action='append',
-    )
-    argparser.add_argument(
-        '--version',
-    )
-
-    args = argparser.parse_args()
-
-    deploy(args.deployment, args.chart, args.environment, args.namespace, args.set, args.version)
-
-if __name__ == '__main__':
-    main()

--- a/hubploy/imagebuilder.py
+++ b/hubploy/imagebuilder.py
@@ -26,7 +26,7 @@ def build_image(client, path, image_spec, cache_from=None, push=False):
             args += ['--cache-from', cf]
 
     if push:
-        args.append('push')
+        args.append('--push')
 
     args.append('.')
 

--- a/hubploy/imagebuilder.py
+++ b/hubploy/imagebuilder.py
@@ -18,16 +18,20 @@ def make_imagespec(path, image_name):
 
 def build_image(client, path, image_spec, cache_from=None, push=False):
     r2d = Repo2Docker()
-    r2d.subdir = path
-    r2d.output_image_spec = image_spec
-    r2d.user_name = 'jovyan'
-    r2d.user_id = 1000
-    r2d.repo = '.'
-    r2d.cache_from = cache_from
-    r2d.initialize()
-    r2d.build()
+    args = ['--subdir', path, '--image-name', image_spec,
+            '--no-run', '--user-name', 'jovyan',
+            '--user-id', '1000']
+    if cache_from:
+        for cf in cache_from:
+            args += ['--cache-from', cf]
+
     if push:
-        r2d.push_image()
+        args.append('push')
+
+    args.append('.')
+
+    r2d.initialize(args)
+    r2d.start()
 
 
 def pull_image(client, image_name, tag):

--- a/hubploy/imagebuilder.py
+++ b/hubploy/imagebuilder.py
@@ -75,28 +75,3 @@ def build_if_needed(client, path, image_name, commit_range, push=False):
     else:
         print(f'Image {image_spec}: already up to date')
         return False
-
-def main():
-    argparser = argparse.ArgumentParser()
-    argparser.add_argument(
-        'path',
-        help='Path to directory with dockerfile'
-    )
-    argparser.add_argument(
-        'image_name',
-        help='Name of image (including repository) to build, without tag'
-    )
-    argparser.add_argument(
-        '--commit-range',
-        help='Trigger image rebuilds only if path has changed in this commit range'
-    )
-    argparser.add_argument(
-        '--push',
-        action='store_true',
-    )
-
-    args = argparser.parse_args()
-
-    client = docker.from_env()
-
-    build_if_needed(client, args.path, args.image_name, args.commit_range, args.push)

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,7 @@ setuptools.setup(
     ],
     entry_points={
         'console_scripts': [
-            'hubploy-image-builder = hubploy.imagebuilder:main',
-            'hubploy-helm-deploy = hubploy.helm:main'
+            'hubploy = hubploy.__main__:main',
         ],
     },
 

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,7 @@ setuptools.setup(
     install_requires=[
         'requests',
         'docker',
-        # FIXME: I can't get dependency_links to work booo. We need master right now.
-        'jupyter-repo2docker',
+        'jupyter-repo2docker>=0.7',
     ],
     entry_points={
         'console_scripts': [

--- a/tests/test_imagebuilder.py
+++ b/tests/test_imagebuilder.py
@@ -86,51 +86,23 @@ def test_imagebuild(git_repo, local_registry):
         f.write('FROM busybox\n')
         f.write('ADD nonce /')
 
-    # Round 1
-    # Make a commit with a random nonce in git repository
-    nonce_1 = commit_nonce(git_repo)
+    nonce = commit_nonce(git_repo)
 
-    # We haven't build this image so far, so it must need building
-    assert imagebuilder.needs_building(client, image_dir, image_name)
+    cur_dir = os.getcwd()
+    try:
+        os.chdir(git_repo)
 
-    # Build the image
-    imagebuilder.build_image(client, image_dir, imagebuilder.make_imagespec(image_dir, image_name))
+        image_spec = imagebuilder.make_imagespec(image_dir, image_name)
+        client = docker.from_env()
+        imagebuilder.build_image(client, image_dir, image_spec, cache_from=None, push=True)
+        client.images.remove(image_spec)
 
-    # Validate that the image we expect to be built / tagged is
-    expected_image_tag_1 = gitutils.last_git_modified(image_dir)
-    expected_image_spec_1 = f'{image_name}:{expected_image_tag_1}'
-    assert client.images.get(expected_image_spec_1) is not None
+        with pytest.raises(docker.errors.ImageNotFound):
+            client.images.get(image_spec)
 
-    # Validate that the image being built is actually what we wanted
-    assert client.containers.run(expected_image_spec_1, 'cat /nonce').decode() == nonce_1
-
-    # Push the image, and verify that we now know we don't need to build it
-    assert imagebuilder.needs_building(client, image_dir, image_name)
-    client.images.push(expected_image_spec_1)
-    assert not imagebuilder.needs_building(client, image_dir, image_name)
-
-    # Round 2! We do this to make sure we handle rebuilding properly
-    # Make a commit with a new random nonce in git repository
-    nonce_2 = commit_nonce(git_repo)
-
-    # We haven't built the image since this commit, so it must need building
-    assert imagebuilder.needs_building(client, image_dir, image_name)
-
-    # Build the image
-    imagebuilder.build_image(client, image_dir, imagebuilder.make_imagespec(image_dir, image_name))
-
-    # Validate that the image we expect to be built / tagged is
-    expected_image_tag_2 = gitutils.last_git_modified(image_dir)
-    expected_image_spec_2 = f'{image_name}:{expected_image_tag_2}'
-    assert client.images.get(expected_image_spec_2) is not None
-
-    # Validate that the image being built is actually what we wanted
-    assert client.containers.run(expected_image_spec_2, 'cat /nonce').decode() == nonce_2
-
-    # Push the image, and verify that we now know we don't need to build it anymore
-    assert imagebuilder.needs_building(client, image_dir, image_name)
-    client.images.push(expected_image_spec_2)
-    assert not imagebuilder.needs_building(client, image_dir, image_name)
+        assert client.containers.run(image_spec, 'cat /nonce').decode().strip() == nonce
+    finally:
+        os.chdir(cur_dir)
 
 
 def test_build_fail(git_repo):


### PR DESCRIPTION
- Use repo2docker to push image as well
- Switch to a master `hubploy` command with build &
  deploy subcommands.
- Use git change ranges rather than docker registry
  api calls to determine when an image needs to be
  built. This works much better with private repositories.
- Depend on released version of repo2docker