### PR TITLE
Detect --commit-range automatically

### DIFF
--- a/hubploy/__main__.py
+++ b/hubploy/__main__.py
@@ -1,6 +1,6 @@
 import argparse
 import hubploy
-from hubploy import helm, auth
+from hubploy import helm, auth, commitrange
 
 
 def main():
@@ -16,7 +16,8 @@ def main():
     trigger_change_group = build_parser.add_mutually_exclusive_group()
     trigger_change_group.add_argument(
         '--commit-range',
-        help='Trigger image rebuilds only if files in image directory have changed in this git commit range'
+        help='Trigger image rebuilds only if files in image directory have changed in this git commit range',
+        default=commitrange.get_commit_range()
     )
     # FIXME: Needs a better name?
     trigger_change_group.add_argument(

--- a/hubploy/__main__.py
+++ b/hubploy/__main__.py
@@ -1,5 +1,6 @@
 import argparse
 import hubploy
+import sys
 from hubploy import helm, auth, commitrange
 
 
@@ -59,6 +60,12 @@ def main():
     config = hubploy.config.get_config(args.deployment)
 
     if args.command == 'build':
+        if not args.check_registry and not args.commit_range:
+            # commit_range autodetection failed, and check registry isn't set
+            # FIXME: Provide an actually useful error message
+            print("Could not auto-detect commit-range, and --check-registry is not set", file=sys.stderr)
+            print("Specify --commit-range manually, or pass --check-registry", file=sys.stderr)
+            sys.exit(1)
 
         if args.push or args.check_registry:
             auth.registry_auth(args.deployment)

--- a/hubploy/commitrange.py
+++ b/hubploy/commitrange.py
@@ -1,0 +1,20 @@
+import os
+import json
+
+
+def get_commit_range():
+    """
+    Auto detect commit range and return it if we can.
+    Else return None
+    """
+    if 'GITHUB_ACTIONS' in os.environ:
+        return get_commit_range_github()
+
+
+def get_commit_range_github():
+    with open(os.environ['GITHUB_EVENT_PATH']) as f:
+        event = json.load(f)
+
+    if 'pull_request' in event:
+        base = event['pull_request']['base']['sha']
+        return f'{base}...HEAD'


### PR DESCRIPTION
Different CI systems have different ways of providing us
this information - some easily & some not. We can add support
for the major providers here so we have some way to automatically
detect it.

This adds support for detecting commit-range value in github
actions.