### PR TITLE
Authenticator Updates (with special attention to AWS)

### DIFF
--- a/hubploy/__main__.py
+++ b/hubploy/__main__.py
@@ -76,7 +76,7 @@ def main():
 
         # Move this line to auth.py so we always use context manager
         #if args.push or args.check_registry:
-        with auth.registry_auth(args.deployment, args.push, args.check_registry) as registry_auth_code:
+        with auth.registry_auth(args.deployment, args.push, args.check_registry):
 
             for image in config.get('images', {}).get('images', {}):
                 if image.needs_building(check_registry=args.check_registry, commit_range=args.commit_range):
@@ -86,5 +86,5 @@ def main():
                         image.push()
 
     elif args.command == 'deploy':
-        with auth.cluster_auth(args.deployment) as cluster_auth_code:
+        with auth.cluster_auth(args.deployment):
             helm.deploy(args.deployment, args.chart, args.environment, args.namespace, args.set, args.version, args.timeout, args.force)

--- a/hubploy/__main__.py
+++ b/hubploy/__main__.py
@@ -74,16 +74,17 @@ def main():
             print("Specify --commit-range manually, or pass --check-registry", file=sys.stderr)
             sys.exit(1)
 
-        if args.push or args.check_registry:
-            auth.registry_auth(args.deployment)
+        # Move this line to auth.py so we always use context manager
+        #if args.push or args.check_registry:
+        with auth.registry_auth(args.deployment, args.push, args.check_registry) as registry_auth_code:
 
-        for image in config.get('images', {}).get('images', {}):
-            if image.needs_building(check_registry=args.check_registry, commit_range=args.commit_range):
-                image.fetch_parent_image()
-                image.build()
-                if args.push:
-                    image.push()
+            for image in config.get('images', {}).get('images', {}):
+                if image.needs_building(check_registry=args.check_registry, commit_range=args.commit_range):
+                    image.fetch_parent_image()
+                    image.build()
+                    if args.push:
+                        image.push()
 
     elif args.command == 'deploy':
-        with auth.cluster_auth(args.deployment):
+        with auth.cluster_auth(args.deployment) as cluster_auth_code:
             helm.deploy(args.deployment, args.chart, args.environment, args.namespace, args.set, args.version, args.timeout, args.force)

--- a/hubploy/__main__.py
+++ b/hubploy/__main__.py
@@ -85,5 +85,5 @@ def main():
                     image.push()
 
     elif args.command == 'deploy':
-        auth.cluster_auth(args.deployment)
-        helm.deploy(args.deployment, args.chart, args.environment, args.namespace, args.set, args.version, args.timeout, args.force)
+        with auth.cluster_auth(args.deployment):
+            helm.deploy(args.deployment, args.chart, args.environment, args.namespace, args.set, args.version, args.timeout, args.force)

--- a/hubploy/auth.py
+++ b/hubploy/auth.py
@@ -19,7 +19,6 @@ def registry_auth(deployment, push, check_registry):
     Do appropriate registry authentication for given deployment
     """
     # Check if authentication needs to be done
-    
     if push or check_registry:
 
         config = get_config(deployment)
@@ -83,13 +82,8 @@ def registry_auth_aws(deployment, project, zone, service_key):
         raise FileNotFoundError(
             f'The service_key file {service_key_path} does not exist')
 
+    # Set env variable for credential file location
     os.environ["AWS_SHARED_CREDENTIALS_FILE"] = service_key_path
-
-    # move credentials to standard location
-    #cred_dir = os.path.expanduser('~/.aws')
-    #if not os.path.isdir(cred_dir):
-    #    os.mkdir(cred_dir)
-    #shutil.copyfile(service_key_path, os.path.join(cred_dir, 'credentials'))
 
     try:
         registry = f'{project}.dkr.ecr.{zone}.amazonaws.com'
@@ -110,6 +104,7 @@ def registry_auth_aws(deployment, project, zone, service_key):
         yield 0
 
     finally:
+        # Unset env variable for credential file location
         os.environ["AWS_SHARED_CREDENTIALS_FILE"] = ""
 
 
@@ -214,17 +209,13 @@ def cluster_auth_aws(deployment, project, cluster, zone, service_key):
 
     This changes *global machine state* on what current kubernetes cluster is!
     """
-    # move credentials to standard location
+    # Get credentials from standard location
     service_key_path = os.path.join(
         'deployments', deployment, 'secrets', service_key
     )
 
+    # Set env variable for credential file location
     os.environ["AWS_SHARED_CREDENTIALS_FILE"] = service_key_path
-
-    #cred_dir = os.path.expanduser('~/.aws')
-    #if not os.path.isdir(cred_dir):
-    #    os.mkdir(cred_dir)
-    #shutil.copyfile(service_key_path, os.path.join(cred_dir, 'credentials'))
 
     try:
         subprocess.check_call(['aws2', 'eks', 'update-kubeconfig',
@@ -232,6 +223,7 @@ def cluster_auth_aws(deployment, project, cluster, zone, service_key):
         yield 0
 
     finally:
+        # Unset env variable for credential file location
         os.environ["AWS_SHARED_CREDENTIALS_FILE"] = ""
 
 

--- a/hubploy/auth.py
+++ b/hubploy/auth.py
@@ -87,7 +87,7 @@ def registry_auth_aws(deployment, project, zone, service_key):
 
     try:
         registry = f'{project}.dkr.ecr.{zone}.amazonaws.com'
-        # amazon-ecr-credential-helper installed in .circleci/config.yaml
+        # Requires amazon-ecr-credential-helper to be already installed
         # this adds necessary line to authenticate docker with ecr
         docker_config_dir = os.path.expanduser('~/.docker')
         os.makedirs(docker_config_dir, exist_ok=True)

--- a/hubploy/auth.py
+++ b/hubploy/auth.py
@@ -105,7 +105,7 @@ def registry_auth_aws(deployment, project, zone, service_key):
 
     finally:
         # Unset env variable for credential file location
-        os.environ["AWS_SHARED_CREDENTIALS_FILE"] = ""
+        del os.environ["AWS_SHARED_CREDENTIALS_FILE"]
 
 
 @contextmanager
@@ -224,7 +224,7 @@ def cluster_auth_aws(deployment, project, cluster, zone, service_key):
 
     finally:
         # Unset env variable for credential file location
-        os.environ["AWS_SHARED_CREDENTIALS_FILE"] = ""
+        del os.environ["AWS_SHARED_CREDENTIALS_FILE"]
 
 
 @contextmanager

--- a/hubploy/auth.py
+++ b/hubploy/auth.py
@@ -64,7 +64,7 @@ def registry_auth_gcloud(deployment, project, service_key):
         'gcloud', 'auth', 'configure-docker'
     ])
 
-    yield 0
+    yield
 
 
 @contextmanager
@@ -101,7 +101,7 @@ def registry_auth_aws(deployment, project, zone, service_key):
         with open(docker_config, 'w') as f:
             json.dump(config, f)
 
-        yield 0
+        yield
 
     finally:
         # Unset env variable for credential file location
@@ -147,7 +147,7 @@ def registry_auth_azure(deployment, resource_group, registry, auth_file):
         '--name', registry
     ])
 
-    yield 0
+    yield
 
 @contextmanager
 def cluster_auth(deployment):
@@ -199,7 +199,7 @@ def cluster_auth_gcloud(deployment, project, cluster, zone, service_key):
         'get-credentials', cluster
     ])
 
-    yield 0
+    yield
 
 
 @contextmanager
@@ -220,7 +220,7 @@ def cluster_auth_aws(deployment, project, cluster, zone, service_key):
     try:
         subprocess.check_call(['aws2', 'eks', 'update-kubeconfig',
                                '--name', cluster, '--region', zone])
-        yield 0
+        yield
 
     finally:
         # Unset env variable for credential file location
@@ -267,7 +267,7 @@ def cluster_auth_azure(deployment, resource_group, cluster, auth_file):
         '--resource-group', resource_group
     ])
 
-    yield 0
+    yield
 
 
 


### PR DESCRIPTION
The functions in `auth.py` have been changed to become context managers to allow only temporary access to credential file locations. The only functions that were changed significantly were the AWS-related ones, which now set and unset the `AWS_SHARED_CREDENTIALS_FILE` environment variable with `os.environ[]`.

`__main__.py` has changed to reflect the fact that `auth.py`'s functions are now context managers. I moved the if statement

```
if args.push or args.check_registry:
```

from `__main__.py` to `registry_auth()` in `auth.py` so that the context manager is always entered. Now, if the if statement isn't passed, the function doesn't do anything, so it should be functionally the same as before.

Resolves #44  and generally treats the AWS credentials files more appropriately.