### PR TITLE
aws Command Fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,7 @@ RUN curl -sSL  https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google
 RUN cd /tmp && \
     curl -sSL "https://d1vvhvl2y92vvt.cloudfront.net/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
     unzip -qq awscliv2.zip && \
-    ./aws/install -i /opt/awscli -b /opt/awscli/bin && \
-    ln -s /opt/awscli/bin/aws2 /opt/awscli/bin/aws
+    ./aws/install -i /opt/awscli -b /opt/awscli/bin
 
 # FIXME: Install multiple versions of helm & choose at runtime
 RUN cd /tmp && mkdir helm && \

--- a/hubploy/auth.py
+++ b/hubploy/auth.py
@@ -218,7 +218,7 @@ def cluster_auth_aws(deployment, project, cluster, zone, service_key):
     os.environ["AWS_SHARED_CREDENTIALS_FILE"] = service_key_path
 
     try:
-        subprocess.check_call(['aws2', 'eks', 'update-kubeconfig',
+        subprocess.check_call(['aws', 'eks', 'update-kubeconfig',
                                '--name', cluster, '--region', zone])
         yield
 


### PR DESCRIPTION
Changing the `aws2` command to `aws`. Also removing the line in the Dockerfile that would generate a symlink, since I think we don't need it.