### PR TITLE
aws Command and Dockerfile fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,7 @@ RUN curl -sSL  https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google
 RUN cd /tmp && \
     curl -sSL "https://d1vvhvl2y92vvt.cloudfront.net/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
     unzip -qq awscliv2.zip && \
-    ./aws/install -i /opt/awscli -b /opt/awscli/bin && \
-    ln -s /opt/awscli/bin/aws2 /opt/awscli/bin/aws
+    ./aws/install -i /opt/awscli -b /opt/awscli/bin
 
 # FIXME: Install multiple versions of helm & choose at runtime
 RUN cd /tmp && mkdir helm && \

--- a/hubploy/auth.py
+++ b/hubploy/auth.py
@@ -197,7 +197,7 @@ def cluster_auth_aws(deployment, project, cluster, zone, service_key):
         os.mkdir(cred_dir)
     shutil.copyfile(service_key_path, os.path.join(cred_dir, 'credentials'))
 
-    subprocess.check_call(['aws2', 'eks', 'update-kubeconfig',
+    subprocess.check_call(['aws', 'eks', 'update-kubeconfig',
                            '--name', cluster, '--region', zone])
 
 


### PR DESCRIPTION
Changed the `aws2` command to `aws`. Also deleted the line in the Dockerfile that tried to create a symlink, I don't think we need it.