### PR TITLE
Error when deployment dir isn't found

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,13 +9,11 @@ jobs:
     working_directory: ~/repo
 
     steps:
+      # We are explictly not caching any of the dependencies / venv
+      # pyenv + venv + caching don't seem to get along well.
+      # See https://circleci.com/gh/yuvipanda/hubploy/154?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link
+      # for an example, causing a setuptools version mismatch
       - checkout
-
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-          - v2-dependencies-3.7.0-{{ checksum "setup.py" }}-{{ checksum "dev-requirements.txt" }}
-          # Don't use any cache if we don't have an exact match
 
       - run:
           name: setup dependencies
@@ -28,11 +26,6 @@ jobs:
             pip install -e .
             git config --global user.email "ci@circleci"
             git config --global user.name "ci"
-
-      - save_cache:
-          paths:
-            - ./venv
-          key: v2-dependencies-3.7.0-{{ checksum "setup.py" }}-{{ checksum "dev-requirements.txt" }}
 
       - run:
           name: run tests

--- a/hubploy/__main__.py
+++ b/hubploy/__main__.py
@@ -78,7 +78,11 @@ def main():
 
     args = argparser.parse_args()
 
-    config = hubploy.config.get_config(args.deployment)
+    try:
+        config = hubploy.config.get_config(args.deployment)
+    except hubploy.config.DeploymentNotFoundError as e:
+        print(e, file=sys.stderr)
+        sys.exit(1)
 
     if args.command == 'build':
         if not args.check_registry and not args.commit_range:


### PR DESCRIPTION
This is most often caused by:

1. Calling hubploy from the wrong directory
2. Typo in deployment name
3. Prefixing the deployment name with `deployment/` to match
   the directory structure.

hubploy will now provide meaningful error messages for each
of these conditions.