### PR TITLE
Ensure `credHelpers` key exists in ~/.docker/config.json

### DIFF
--- a/hubploy/auth.py
+++ b/hubploy/auth.py
@@ -88,8 +88,9 @@ def registry_auth_aws(deployment, project, zone, service_key):
         with open(docker_config, 'r') as f:
             config = json.load(f)
     else:
-        config = {'credHelpers': {}}
-    config['credHelpers'][registry] = 'ecr-login'
+        config = {}
+
+    config.setdefault('credHelpers', {})[registry] = 'ecr-login'
     with open(docker_config, 'w') as f:
         json.dump(config, f)
 


### PR DESCRIPTION
`hubploy build` authenticates to AWS ECR by adding an `credHelpers`
entry pointing to [ecr-login](1) to ~/.docker/config.json.
If a ~/.docker/config.json file already exists but does not
have a `credHelpers` entry, a KeyError was raised and hubploy
failed.

[1]: https://github.com/awslabs/amazon-ecr-credential-helper