### PR TITLE
Manually upgrade setuptools

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
             pyenv global 3.7.0
             python3 -m venv venv
             source venv/bin/activate
-            pip install --upgrade pip
+            pip install --upgrade pip setuptools
             pip install -r dev-requirements.txt
             pip install -e .
             git config --global user.email "ci@circleci"


### PR DESCRIPTION
So it looks like your most recent hubploy build has this line in the CircleCI build job's logs

```
ERROR: google-auth 1.12.0 has requirement setuptools>=40.3.0, but you'll have setuptools 39.0.1 which is incompatible.
```

It's weird, because the build doesn't break then, but the next time it uses cached dependencies (which I noticed you took out, but I haven't played with).

I implemented a solution I found which really just includes `setuptools` in the `pip install --upgrade` command. Here's a quick PR for that.