### PR TITLE
Support --set-string and avoid numerical image tag bug

### DIFF
--- a/hubploy/__main__.py
+++ b/hubploy/__main__.py
@@ -58,6 +58,10 @@ def main():
         action='append',
     )
     deploy_parser.add_argument(
+        '--set-string',
+        action='append',
+    )
+    deploy_parser.add_argument(
         '--version',
     )
     deploy_parser.add_argument(
@@ -102,7 +106,19 @@ def main():
 
     elif args.command == 'deploy':
         with auth.cluster_auth(args.deployment):
-            helm.deploy(args.deployment, args.chart, args.environment, args.namespace, args.set, args.version, args.timeout, args.force, args.atomic, args.cleanup_on_fail)
+            helm.deploy(
+                args.deployment,
+                args.chart,
+                args.environment,
+                args.namespace,
+                args.set,
+                args.set_string,
+                args.version,
+                args.timeout,
+                args.force,
+                args.atomic,
+                args.cleanup_on_fail,
+            )
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
When using the helm CLI and `--set`, it cannot know when it receives
it's argument if the value was meant as a string or as an integer if it
receives the string `12334567`.

The helm CLI has opted to have the `--set-string` flag to enforce a set
value to be a string value even if it looks numerical. We should ensure
that we always set image tags and names as strings, or we run into
issues like https://github.com/earthlab/hub-ops/pull/199#issuecomment-619099629.