### PR TITLE
Add support for a 'secrets' submodule

### DIFF
--- a/hubploy/helm.py
+++ b/hubploy/helm.py
@@ -150,7 +150,7 @@ def deploy(
     # Check for same pattern of files in a dir called 'secrets'
     # This supports keeping the secrets in a different git repo
     helm_secret_repo_files = [
-        f for f in helm_config_files
+        os.path.join('secrets', f) for f in helm_config_files
         if os.path.exists(os.path.join('secrets', f))
     ]
 

--- a/hubploy/helm.py
+++ b/hubploy/helm.py
@@ -147,6 +147,13 @@ def deploy(
         os.path.join('deployments', deployment, 'secrets', f'{environment}.yaml'),
     ] if os.path.exists(f)]
 
+    # Check for same pattern of files in a dir called 'secrets'
+    # This supports keeping the secrets in a different git repo
+    helm_secret_repo_files = [
+        f for f in helm_config_files
+        if os.path.exists(os.path.join('secrets', f))
+    ]
+
     for image in config['images']['images']:
         # We can support other charts that wrap z2jh by allowing various
         # config paths where we set image tags and names.
@@ -159,7 +166,7 @@ def deploy(
         name,
         namespace,
         chart,
-        helm_config_files,
+        helm_config_files + helm_secret_repo_files,
         helm_config_overrides_implicit,
         helm_config_overrides_string,
         version,


### PR DESCRIPTION
Often, you want to keep all your secrets in an entirely
different git repo than your public deployment repo. With
this change, the 'secret' repo can be referenced here as a
submodule in the path 'secrets'. The same config paths
(deployments/<deployment>/(config|secret)/(common|staging|prod).yaml)
works inside the secrets repo too.