### PR TITLE
Update Dockerfile's gcloud and helm versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV PATH ${VENV_PATH}:/opt/google-cloud-sdk/bin:/opt/awscli/bin:${PATH}
 # Force gcloud to run on python3 ugh
 ENV CLOUDSDK_PYTHON python3
 
-RUN curl -sSL  https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-265.0.0-linux-x86_64.tar.gz | tar -xzf - -C /opt/
+RUN curl -sSL  https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-296.0.1-linux-x86_64.tar.gz | tar -xzf - -C /opt/
 
 RUN cd /tmp && \
     curl -sSL "https://d1vvhvl2y92vvt.cloudfront.net/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
@@ -19,12 +19,12 @@ RUN cd /tmp && \
 
 # FIXME: Install multiple versions of helm & choose at runtime
 RUN cd /tmp && mkdir helm && \
-    curl -sSL https://get.helm.sh/helm-v2.14.3-linux-amd64.tar.gz | tar -xzf - -C helm && \
+    curl -sSL https://get.helm.sh/helm-v2.16.8-linux-amd64.tar.gz | tar -xzf - -C helm && \
     mv helm/linux-amd64/helm /usr/local/bin/helm && \
     rm -rf helm
 
 RUN cd /tmp && mkdir helm && \
-    curl -sSL https://get.helm.sh/helm-v3.0.2-linux-amd64.tar.gz | tar -xzf - -C helm && \
+    curl -sSL https://get.helm.sh/helm-v3.2.3-linux-amd64.tar.gz | tar -xzf - -C helm && \
     mv helm/linux-amd64/helm /usr/local/bin/helm3 && \
     rm -rf helm
 


### PR DESCRIPTION
There are some security patches for helm and such that I think make sense and I recall there are some clear recommendations to not use helm versions older than 2.15.

For the gcloud bump I'm not sure what has happened since and it just felt like a good idea to not have it quite outdated. I can imagine this could cause some breaking change but I have not tested anything about it.