### PR TITLE
Dockerfile: sops added, helm2 binary, version bumps, refactoring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,7 @@ ENV PATH ${VENV_PATH}:/opt/google-cloud-sdk/bin:/opt/awscli/bin:${PATH}
 
 # Force gcloud to run on python3 ugh
 ENV CLOUDSDK_PYTHON python3
-
-RUN curl -sSL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-296.0.1-linux-x86_64.tar.gz | tar -xzf - -C /opt/
+RUN curl -sSL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-298.0.0-linux-x86_64.tar.gz | tar -xzf - -C /opt/
 
 RUN cd /tmp && \
     curl -sSL "https://d1vvhvl2y92vvt.cloudfront.net/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,36 @@
 FROM python:3.7-slim-buster
 
-RUN apt-get update && \
-    apt-get install --yes --no-install-recommends git curl git-crypt unzip amazon-ecr-credential-helper file && \
-    rm -rf /var/lib/apt/lists/*
+# Software in Dockerfile to manually bump versions on:
+# - gcloud: https://cloud.google.com/sdk/docs/downloads-versioned-archives
+# - helm: https://github.com/helm/helm/releases
+# - sops: https://github.com/mozilla/sops/releases
 
-ENV VENV_PATH /opt/venv
-ENV PATH ${VENV_PATH}:/opt/google-cloud-sdk/bin:/opt/awscli/bin:${PATH}
+RUN apt-get update \
+ && apt-get install --yes --no-install-recommends \
+        amazon-ecr-credential-helper \
+        curl \
+        file \
+        git \
+        git-crypt \
+        unzip \
+ && rm -rf /var/lib/apt/lists/*
 
 # Install gcloud CLI
 # Force gcloud to run on python3 ugh
 ENV CLOUDSDK_PYTHON python3
+ENV PATH=/opt/google-cloud-sdk/bin:${PATH}
 RUN curl -sSL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-298.0.0-linux-x86_64.tar.gz | tar -xzf - -C /opt/
 
 # Install aws CLI
+ENV PATH=/opt/awscli/bin:${PATH}
 RUN cd /tmp && \
-    curl -sSL "https://d1vvhvl2y92vvt.cloudfront.net/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    curl -sSL https://d1vvhvl2y92vvt.cloudfront.net/awscli-exe-linux-x86_64.zip -o awscliv2.zip && \
     unzip -qq awscliv2.zip && \
     ./aws/install -i /opt/awscli -b /opt/awscli/bin
 
 # Install SOPS
 RUN cd /tmp && \
-    curl -sSL -o sops.deb https://github.com/mozilla/sops/releases/download/v3.5.0/sops_3.5.0_amd64.deb && \
+    curl -sSL https://github.com/mozilla/sops/releases/download/v3.5.0/sops_3.5.0_amd64.deb -o sops.deb && \
     apt-get install ./sops.deb && \
     rm sops.deb
 
@@ -33,8 +43,12 @@ RUN cd /tmp && mkdir helm && \
     mv helm/linux-amd64/helm /usr/local/bin/helm3 && \
     rm -rf helm
 
+# Setup a virtual environment
+ENV VENV_PATH=/opt/venv
+ENV PATH=${VENV_PATH}:${PATH}
 RUN python3 -m venv ${VENV_PATH}
 
+# Install hubploy
 COPY . /srv/repo
 RUN python3 -m pip install --no-cache-dir /srv/repo
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,14 +34,15 @@ RUN cd /tmp && \
     apt-get install ./sops.deb && \
     rm sops.deb
 
-# Download helm v2/v3 to helm/helm3. Make hubploy use a specific binary with
-# HELM_EXECUTABLE environment variable.
+# Download helm v2/v3 to helm2/helm3 and symlink helm2 to helm. Make hubploy use
+# a specific binary with HELM_EXECUTABLE environment variable.
 RUN cd /tmp && mkdir helm && \
     curl -sSL https://get.helm.sh/helm-v2.16.9-linux-amd64.tar.gz | tar -xzf - -C helm && \
-    mv helm/linux-amd64/helm /usr/local/bin/helm && \
+    mv helm/linux-amd64/helm /usr/local/bin/helm2 && \
     curl -sSL https://get.helm.sh/helm-v3.2.4-linux-amd64.tar.gz | tar -xzf - -C helm && \
     mv helm/linux-amd64/helm /usr/local/bin/helm3 && \
-    rm -rf helm
+    rm -rf helm && \
+    ln -s /usr/local/bin/helm2 /usr/local/bin/helm
 
 # Setup a virtual environment
 ENV VENV_PATH=/opt/venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV PATH ${VENV_PATH}:/opt/google-cloud-sdk/bin:/opt/awscli/bin:${PATH}
 # Force gcloud to run on python3 ugh
 ENV CLOUDSDK_PYTHON python3
 
-RUN curl -sSL  https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-296.0.1-linux-x86_64.tar.gz | tar -xzf - -C /opt/
+RUN curl -sSL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-296.0.1-linux-x86_64.tar.gz | tar -xzf - -C /opt/
 
 RUN cd /tmp && \
     curl -sSL "https://d1vvhvl2y92vvt.cloudfront.net/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
@@ -19,12 +19,12 @@ RUN cd /tmp && \
 
 # FIXME: Install multiple versions of helm & choose at runtime
 RUN cd /tmp && mkdir helm && \
-    curl -sSL https://get.helm.sh/helm-v2.16.8-linux-amd64.tar.gz | tar -xzf - -C helm && \
+    curl -sSL https://get.helm.sh/helm-v2.16.9-linux-amd64.tar.gz | tar -xzf - -C helm && \
     mv helm/linux-amd64/helm /usr/local/bin/helm && \
     rm -rf helm
 
 RUN cd /tmp && mkdir helm && \
-    curl -sSL https://get.helm.sh/helm-v3.2.3-linux-amd64.tar.gz | tar -xzf - -C helm && \
+    curl -sSL https://get.helm.sh/helm-v3.2.4-linux-amd64.tar.gz | tar -xzf - -C helm && \
     mv helm/linux-amd64/helm /usr/local/bin/helm3 && \
     rm -rf helm
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,22 +7,28 @@ RUN apt-get update && \
 ENV VENV_PATH /opt/venv
 ENV PATH ${VENV_PATH}:/opt/google-cloud-sdk/bin:/opt/awscli/bin:${PATH}
 
+# Install gcloud CLI
 # Force gcloud to run on python3 ugh
 ENV CLOUDSDK_PYTHON python3
 RUN curl -sSL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-298.0.0-linux-x86_64.tar.gz | tar -xzf - -C /opt/
 
+# Install aws CLI
 RUN cd /tmp && \
     curl -sSL "https://d1vvhvl2y92vvt.cloudfront.net/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
     unzip -qq awscliv2.zip && \
     ./aws/install -i /opt/awscli -b /opt/awscli/bin
 
-# FIXME: Install multiple versions of helm & choose at runtime
+# Install SOPS
+RUN cd /tmp && \
+    curl -sSL -o sops.deb https://github.com/mozilla/sops/releases/download/v3.5.0/sops_3.5.0_amd64.deb && \
+    apt-get install ./sops.deb && \
+    rm sops.deb
+
+# Download helm v2/v3 to helm/helm3. Make hubploy use a specific binary with
+# HELM_EXECUTABLE environment variable.
 RUN cd /tmp && mkdir helm && \
     curl -sSL https://get.helm.sh/helm-v2.16.9-linux-amd64.tar.gz | tar -xzf - -C helm && \
     mv helm/linux-amd64/helm /usr/local/bin/helm && \
-    rm -rf helm
-
-RUN cd /tmp && mkdir helm && \
     curl -sSL https://get.helm.sh/helm-v3.2.4-linux-amd64.tar.gz | tar -xzf - -C helm && \
     mv helm/linux-amd64/helm /usr/local/bin/helm3 && \
     rm -rf helm


### PR DESCRIPTION
I wanted to start using hubploy in github actions at github.com/neurohackademy/nh-2020 and concluded that perhaps I wanted to use this Docker container somehow, but then I wanted SOPS installed in it.

- Installed SOPS
- Made `helm` a symlink pointing to `helm2`, which allow users to ping helm2 easier if we transition to helm3 as a default.
- Bumped a patch version of helm2 and helm3
- Bumped gcloud version
- Refactored the Dockerfile a bit and added some comments