### PR TITLE
GitHub Actions: detect commit range for pushes as well

### DIFF
--- a/hubploy/commitrange.py
+++ b/hubploy/commitrange.py
@@ -18,9 +18,22 @@ def get_commit_range():
 
 
 def get_commit_range_github():
+    """
+    Auto detects commit range for pull requests and pushes from within a GitHub
+    Action job using environment variables and .json file describing the event
+    triggering the job.
+
+    About env vars:     https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables
+    About event file:   https://developer.github.com/webhooks/event-payloads/
+    """
     with open(os.environ['GITHUB_EVENT_PATH']) as f:
         event = json.load(f)
 
+    # pull_request ref: https://developer.github.com/webhooks/event-payloads/#pull_request
     if 'pull_request' in event:
         base = event['pull_request']['base']['sha']
         return f'{base}...HEAD'
+
+    # push ref: https://developer.github.com/webhooks/event-payloads/#push
+    if 'before' in event:
+        return f"{event['before']}...HEAD"


### PR DESCRIPTION
I noticed how my pushed commits to neurohackademy/nh-2020 failed ([example here](https://github.com/neurohackademy/nh-2020/runs/816406853)) because I had not specified a commit-range when I ran `hubploy build`. I expected the commit range detection code I've read about to resolve this but I think that only works in association with pull requests.

Due to this, I've added this to stop rebuilds for happening when nothing is really changing. I've also learned that the deployment will happen no matter and is using a tag from the latest changed commit and thereby ignoring a any passed commit range.