### PR TITLE
AWS Terminology Updates

### DIFF
--- a/docs/reference/reference-hubploy-configuration-values.rst
+++ b/docs/reference/reference-hubploy-configuration-values.rst
@@ -18,8 +18,8 @@ Here is the ``hubploy.yaml`` file that comes with cloning hubploy-template::
 	      service_key: gcr-key.json
 	    aws:
 	      # Pushes to Amazon ECR
-	      project: # TODO: AWS account id
-	      zone: # TODO: Zone in which your container image should live. Match your cluster's zone
+	      account_id: # TODO: AWS account id
+	      region: # TODO: Zone in which your container image should live. Match your cluster's zone
 	      # TODO: Get AWS credentials that can push to ECR, in same format as ~/.aws/credentials
 	      # then put them in secrets/aws-ecr-config.cfg
 	      service_key: aws-ecr-config.cfg
@@ -33,8 +33,8 @@ Here is the ``hubploy.yaml`` file that comes with cloning hubploy-template::
 	    # Make a service key with permissions to talk to your cluster, put it in secrets/gkee-key.json
 	    service_key: gke-key.json
 	  aws:
-	    project: # TODO: AWS account id
-	    zone: # TODO: Zone or region in which your cluster is set up
+	    account_id: # TODO: AWS account id
+	    region: # TODO: Zone or region in which your cluster is set up
 	    cluster: # TODO: The name of your EKS cluster
 	    # TODO: Get AWS credentials that can access your EKS cluster, in same format as ~/.aws credentials
 	    # then put them in secrets/aws-eks-config.cfg
@@ -82,13 +82,13 @@ rename this file, but you will also need put the new filename here.
 aws
 ^^^
 
-project
-"""""""
+account_id
+""""""""""
 
 AWS account ID
 
-zone
-""""
+region
+""""""
 
 The zone in which your ECR image will live. This should match the zone where your cluster will 
 live. 
@@ -142,8 +142,8 @@ You can rename this file, but you will also need put the new filename here.
 aws
 ---
 
-project
-^^^^^^^
+account_id
+^^^^^^^^^^
 
 AWS account ID
 
@@ -152,8 +152,8 @@ cluster
 
 The name of the EKS cluster you will create.
 
-zone
-^^^^
+region
+^^^^^^
 
 Zone or region this cluster will sit in.
 

--- a/hubploy/__main__.py
+++ b/hubploy/__main__.py
@@ -115,13 +115,15 @@ def main():
             else:
                 build_images = all_images
 
-            print(f"Building {len(build_images)} images")
+            print(f"Images found: {len(build_images)}")
             for image in build_images:
                 if image.needs_building(check_registry=args.check_registry, commit_range=args.commit_range):
                     print(f"Building image {image.name}")
                     image.build(not args.no_cache)
                     if args.push:
                         image.push()
+                else:
+                    print(f"{image.name} does not require building")
 
     elif args.command == 'deploy':
         with auth.cluster_auth(args.deployment):

--- a/hubploy/auth.py
+++ b/hubploy/auth.py
@@ -77,7 +77,7 @@ def registry_auth_gcloud(deployment, project, service_key):
     yield
 
 
-def registry_auth_aws(deployment, project, zone, service_key=None, role_arn=None):
+def registry_auth_aws(deployment, account_id, region, service_key=None, role_arn=None):
     """
     Setup AWS authentication to ECR container registry
 
@@ -88,7 +88,7 @@ def registry_auth_aws(deployment, project, zone, service_key=None, role_arn=None
         raise Exception('AWS authentication requires either a service key or the use of a role')
 
     try:
-        registry = f'{project}.dkr.ecr.{zone}.amazonaws.com'
+        registry = f'{account_id}.dkr.ecr.{region}.amazonaws.com'
 
         if service_key:
             # Get credentials from standard location
@@ -257,7 +257,7 @@ def cluster_auth_gcloud(deployment, project, cluster, zone, service_key):
     yield
 
 
-def cluster_auth_aws(deployment, project, cluster, zone, service_key=None, role_arn=None):
+def cluster_auth_aws(deployment, account_id, cluster, region, service_key=None, role_arn=None):
     """
     Setup AWS authentication with service_key or with a role
 
@@ -300,7 +300,7 @@ def cluster_auth_aws(deployment, project, cluster, zone, service_key=None, role_
 
         subprocess.check_call([
             'aws', 'eks', 'update-kubeconfig',
-            '--name', cluster, '--region', zone
+            '--name', cluster, '--region', region
         ])
 
         yield

--- a/hubploy/config.py
+++ b/hubploy/config.py
@@ -203,4 +203,23 @@ def get_config(deployment):
 
         config['images']['images'] = [LocalImage(**i) for i in images]
 
+        # FIXME: Does not currently support multiple images in the images block
+        # Backwards compatibility checker for images block
+        if config['images']['registry']['provider'] == 'aws' and 'project' in config['images']['registry']['aws']:
+            config['images']['registry']['aws']['account_id'] = config['images']['registry']['aws']['project']
+            del config['images']['registry']['aws']['project']
+
+        if config['images']['registry']['provider'] == 'aws' and 'zone' in config['images']['registry']['aws']:
+            config['images']['registry']['aws']['region'] = config['images']['registry']['aws']['zone']
+            del config['images']['registry']['aws']['zone']
+
+        # Backwards compatibility checker for cluster block
+        if config['cluster']['provider'] == 'aws' and 'project' in config['cluster']['aws']:
+            config['cluster']['aws']['account_id'] = config['cluster']['aws']['project']
+            del config['cluster']['aws']['project']
+
+        if config['cluster']['provider'] == 'aws' and 'zone' in config['cluster']['aws']:
+            config['cluster']['aws']['region'] = config['cluster']['aws']['zone']
+            del config['cluster']['aws']['zone']
+
     return config


### PR DESCRIPTION
Updates the terminology used for AWS deployment specifications. Closes #41 .

Should be backwards compatible. Copying my comment from the issue this will close:

>I'll update the function signatures, docs, and hubploy-template, but I think it'll be automatically backwards compatible! Since the functions take in their parameters like this:
> ```
>           elif provider == 'aws':
>               yield from registry_auth_aws(
>                   deployment, **registry['aws']
>               )
>```
> I don't think the names of the entries in hubploy.yaml matter, but the order does.

Will update and notify about `hubploy-template` before merging.