### PR TITLE
Let GitHub Actions commit range detection crash gracefully on --force pushes

### DIFF
--- a/hubploy/commitrange.py
+++ b/hubploy/commitrange.py
@@ -7,6 +7,7 @@ Current CI systems supported: GitHub Actions.
 import os
 import json
 
+from hubploy.utils import is_commit
 
 def get_commit_range():
     """
@@ -36,4 +37,8 @@ def get_commit_range_github():
 
     # push ref: https://developer.github.com/webhooks/event-payloads/#push
     if 'before' in event:
-        return f"{event['before']}...HEAD"
+        if not is_commit(event['before']):
+            print(f"A GitHub Actions environment was detected, but the constructed commit range ({event['before']}...HEAD) was invalid. This can happen if a git push --force has been run.")
+            return None
+        else:
+            return f"{event['before']}...HEAD"

--- a/hubploy/utils.py
+++ b/hubploy/utils.py
@@ -67,3 +67,11 @@ def path_touched(*paths, commit_range):
     return subprocess.check_output([
         'git', 'diff', '--name-only', commit_range, '--', *paths
     ]).decode('utf-8').strip() != ''
+
+
+def is_commit(ref):
+    try:
+        subprocess.check_call(['git', 'cat-file', 'commit', ref])
+        return True
+    except subprocess.CalledProcessError:
+        return False


### PR DESCRIPTION
This addresses https://github.com/yuvipanda/hubploy/issues/90 to some degree. It doesn't really help much until we also have a fallback behavior that isn't sys.exit(1) when a commit range isn't provided either manually or automatically.
