### PR TITLE
Just in time use of cluster credentials

### DIFF
--- a/hubploy/__main__.py
+++ b/hubploy/__main__.py
@@ -126,20 +126,19 @@ def main():
                     print(f"{image.name} does not require building")
 
     elif args.command == 'deploy':
-        with auth.cluster_auth(args.deployment):
-            helm.deploy(
-                args.deployment,
-                args.chart,
-                args.environment,
-                args.namespace,
-                args.set,
-                args.set_string,
-                args.version,
-                args.timeout,
-                args.force,
-                args.atomic,
-                args.cleanup_on_fail,
-            )
+        helm.deploy(
+            args.deployment,
+            args.chart,
+            args.environment,
+            args.namespace,
+            args.set,
+            args.set_string,
+            args.version,
+            args.timeout,
+            args.force,
+            args.atomic,
+            args.cleanup_on_fail,
+        )
 
 if __name__ == '__main__':
     main()

--- a/hubploy/helm.py
+++ b/hubploy/helm.py
@@ -28,7 +28,7 @@ from kubernetes.client import CoreV1Api, rest
 from kubernetes.client.models import V1Namespace, V1ObjectMeta
 
 from hubploy.config import get_config
-from hubploy.auth import decrypt_file
+from hubploy.auth import decrypt_file, cluster_auth
 
 
 HELM_EXECUTABLE = os.environ.get('HELM_EXECUTABLE', 'helm')
@@ -173,6 +173,8 @@ def deploy(
     with ExitStack() as stack:
         decrypted_secret_files = [stack.enter_context(decrypt_file(f)) for f in helm_secret_files]
 
+        # Just in time for k8s access, activate the cluster credentials
+        stack.enter_context(cluster_auth(deployment))
         helm_upgrade(
             name,
             namespace,


### PR DESCRIPTION
My current setup is very tightly scoped with its permissions. I have an AWS user _hubploy_, and two AWS roles that the hubploy user can assume, one for ecr (image pushes) and one for eks (k8s access). The hubploy user itself has KMS rights.

In this PR I activate the cluster credentials just before we use `helm` to deploy, rather than earlier that requires the cluster credentials to also be able to decrypt files with KMS rights when using sops.

