### PR TITLE
aws: registry_auth_aws fixes

### DIFF
--- a/hubploy/auth.py
+++ b/hubploy/auth.py
@@ -94,6 +94,9 @@ def registry_auth_gcloud(deployment, project, service_key):
     yield
 
 
+# FIXME: Refactor registry_auth_aws and cluster_auth_aws to use the same logic
+#        of updating environment variables. Making use of a contextlib.ExitStack
+#        is probably sensible.
 def registry_auth_aws(deployment, account_id, region, service_key=None, role_arn=None):
     """
     Setup AWS authentication to ECR container registry
@@ -140,6 +143,7 @@ def registry_auth_aws(deployment, account_id, region, service_key=None, role_arn
         else:
             raise Exception('AWS authentication requires either service_key or role_arn to be configured.')
 
+        # FIXME: Use a temporary docker config
         # Requires amazon-ecr-credential-helper to already be installed
         # this adds necessary line to authenticate docker with ecr
         docker_config_dir = os.path.expanduser('~/.docker')
@@ -159,7 +163,6 @@ def registry_auth_aws(deployment, account_id, region, service_key=None, role_arn
 
     finally:
         if service_key:
-            # Unset env variable for credential file location
             unset_env_var("AWS_SHARED_CREDENTIALS_FILE", original_credential_file_loc)
         else:
             unset_env_var('AWS_ACCESS_KEY_ID', original_access_key_id)
@@ -331,9 +334,7 @@ def cluster_auth_aws(deployment, account_id, cluster, region, service_key=None, 
 
     finally:
         if service_key:
-            # Unset env variable for credential file location
             unset_env_var("AWS_SHARED_CREDENTIALS_FILE", original_credential_file_loc)
-
         else:
             unset_env_var('AWS_ACCESS_KEY_ID', original_access_key_id)
             unset_env_var('AWS_SECRET_ACCESS_KEY', original_secret_access_key)

--- a/hubploy/auth.py
+++ b/hubploy/auth.py
@@ -141,13 +141,10 @@ def registry_auth_aws(deployment, account_id, region, service_key=None, role_arn
             original_secret_access_key = os.environ.get("AWS_SECRET_ACCESS_KEY", None)
             original_session_token = os.environ.get("AWS_SESSION_TOKEN", None)
 
-            # this doesn't come back in the sts client response
-            role_session_name = 'registry'
-
             sts_client = boto3.client('sts')
             assumed_role_object = sts_client.assume_role(
                 RoleArn=role_arn,
-                RoleSessionName=role_session_name
+                RoleSessionName="hubploy-registry-auth"
             )
 
             creds = assumed_role_object['Credentials']
@@ -308,13 +305,10 @@ def cluster_auth_aws(deployment, account_id, cluster, region, service_key=None, 
             original_secret_access_key = os.environ.get("AWS_SECRET_ACCESS_KEY", None)
             original_session_token = os.environ.get("AWS_SESSION_TOKEN", None)
 
-            # this doesn't come back in the sts client response
-            role_session_name = 'cluster'
-
             sts_client = boto3.client('sts')
             assumed_role_object=sts_client.assume_role(
                 RoleArn=role_arn,
-                RoleSessionName=role_session_name
+                RoleSessionName="hubploy-cluster-auth"
             )
 
             creds = assumed_role_object['Credentials']

--- a/hubploy/auth.py
+++ b/hubploy/auth.py
@@ -108,16 +108,15 @@ def registry_auth_aws(deployment, account_id, region, service_key=None, role_arn
         registry = f'{account_id}.dkr.ecr.{region}.amazonaws.com'
 
         if service_key:
+            original_credential_file_loc = os.environ.get("AWS_SHARED_CREDENTIALS_FILE", None)
+
             # Get credentials from standard location
             service_key_path = os.path.join(
                 'deployments', deployment, 'secrets', service_key
             )
-
             if not os.path.isfile(service_key_path):
                 raise FileNotFoundError(
                     f'The service_key file {service_key_path} does not exist')
-
-            original_credential_file_loc = os.environ.get("AWS_SHARED_CREDENTIALS_FILE", None)
 
             # Set env variable for credential file location
             os.environ["AWS_SHARED_CREDENTIALS_FILE"] = service_key_path
@@ -138,6 +137,10 @@ def registry_auth_aws(deployment, account_id, region, service_key=None, role_arn
                 json.dump(config, f)
 
         elif role_arn:
+            original_access_key_id = os.environ.get("AWS_ACCESS_KEY_ID", None)
+            original_secret_access_key = os.environ.get("AWS_SECRET_ACCESS_KEY", None)
+            original_session_token = os.environ.get("AWS_SESSION_TOKEN", None)
+
             # this doesn't come back in the sts client response
             role_session_name = 'registry'
 
@@ -146,10 +149,6 @@ def registry_auth_aws(deployment, account_id, region, service_key=None, role_arn
                 RoleArn=role_arn,
                 RoleSessionName=role_session_name
             )
-
-            original_access_key_id = os.environ.get("AWS_ACCESS_KEY_ID", None)
-            original_secret_access_key = os.environ.get("AWS_SECRET_ACCESS_KEY", None)
-            original_session_token = os.environ.get("AWS_SESSION_TOKEN", None)
 
             creds = assumed_role_object['Credentials']
             os.environ['AWS_ACCESS_KEY_ID'] = creds['AccessKeyId']
@@ -294,17 +293,21 @@ def cluster_auth_aws(deployment, account_id, cluster, region, service_key=None, 
 
     try:
         if service_key:
+            original_credential_file_loc = os.environ.get("AWS_SHARED_CREDENTIALS_FILE", None)
+
             # Get credentials from standard location
             service_key_path = os.path.join(
                 'deployments', deployment, 'secrets', service_key
             )
 
-            original_credential_file_loc = os.environ.get("AWS_SHARED_CREDENTIALS_FILE", None)
-
             # Set env variable for credential file location
             os.environ["AWS_SHARED_CREDENTIALS_FILE"] = service_key_path
 
         elif role_arn:
+            original_access_key_id = os.environ.get("AWS_ACCESS_KEY_ID", None)
+            original_secret_access_key = os.environ.get("AWS_SECRET_ACCESS_KEY", None)
+            original_session_token = os.environ.get("AWS_SESSION_TOKEN", None)
+
             # this doesn't come back in the sts client response
             role_session_name = 'cluster'
 
@@ -313,10 +316,6 @@ def cluster_auth_aws(deployment, account_id, cluster, region, service_key=None, 
                 RoleArn=role_arn,
                 RoleSessionName=role_session_name
             )
-
-            original_access_key_id = os.environ.get("AWS_ACCESS_KEY_ID", None)
-            original_secret_access_key = os.environ.get("AWS_SECRET_ACCESS_KEY", None)
-            original_session_token = os.environ.get("AWS_SESSION_TOKEN", None)
 
             creds = assumed_role_object['Credentials']
             os.environ['AWS_ACCESS_KEY_ID'] = creds['AccessKeyId']

--- a/hubploy/auth.py
+++ b/hubploy/auth.py
@@ -121,21 +121,6 @@ def registry_auth_aws(deployment, account_id, region, service_key=None, role_arn
             # Set env variable for credential file location
             os.environ["AWS_SHARED_CREDENTIALS_FILE"] = service_key_path
 
-            # Requires amazon-ecr-credential-helper to already be installed
-            # this adds necessary line to authenticate docker with ecr
-            docker_config_dir = os.path.expanduser('~/.docker')
-            os.makedirs(docker_config_dir, exist_ok=True)
-            docker_config = os.path.join(docker_config_dir, 'config.json')
-            if os.path.exists(docker_config):
-                with open(docker_config, 'r') as f:
-                    config = json.load(f)
-            else:
-                config = {}
-
-            config.setdefault('credHelpers', {})[registry] = 'ecr-login'
-            with open(docker_config, 'w') as f:
-                json.dump(config, f)
-
         elif role_arn:
             original_access_key_id = os.environ.get("AWS_ACCESS_KEY_ID", None)
             original_secret_access_key = os.environ.get("AWS_SECRET_ACCESS_KEY", None)
@@ -154,6 +139,21 @@ def registry_auth_aws(deployment, account_id, region, service_key=None, role_arn
 
         else:
             raise Exception('AWS authentication requires either service_key or role_arn to be configured.')
+
+        # Requires amazon-ecr-credential-helper to already be installed
+        # this adds necessary line to authenticate docker with ecr
+        docker_config_dir = os.path.expanduser('~/.docker')
+        os.makedirs(docker_config_dir, exist_ok=True)
+        docker_config = os.path.join(docker_config_dir, 'config.json')
+        if os.path.exists(docker_config):
+            with open(docker_config, 'r') as f:
+                config = json.load(f)
+        else:
+            config = {}
+
+        config.setdefault('credHelpers', {})[registry] = 'ecr-login'
+        with open(docker_config, 'w') as f:
+            json.dump(config, f)
 
         yield
 

--- a/hubploy/auth.py
+++ b/hubploy/auth.py
@@ -296,6 +296,9 @@ def cluster_auth_aws(deployment, account_id, cluster, region, service_key=None, 
             service_key_path = os.path.join(
                 'deployments', deployment, 'secrets', service_key
             )
+            if not os.path.isfile(service_key_path):
+                raise FileNotFoundError(
+                    f'The service_key file {service_key_path} does not exist')
 
             # Set env variable for credential file location
             os.environ["AWS_SHARED_CREDENTIALS_FILE"] = service_key_path


### PR DESCRIPTION
## Changes
- __Serious bugfix__
  Make hubploy update docker config when role_arn is used.
- __Micro bugfix__
  Make hubploy set variables early so we avoid risking variable unset errors in our finally clause.
- __Loud failure 1__
  Make hubploy fail loudly if service_key is invalid
- __Loud failure 2__
  Let hubploy fail loudly if both service_key and role_arn are passed

## Review recommendation
Review commit by commit, they are quite cohesive logically to represent the changes listed.
