### PR TITLE
Print list of installed packages after image build

### DIFF
--- a/hubploy/__main__.py
+++ b/hubploy/__main__.py
@@ -123,7 +123,7 @@ def main():
                     if args.push:
                         image.push()
                 else:
-                    print(f"{image.name} does not require building")
+                    print(f"{image.image_spec} does not require building")
 
     elif args.command == 'deploy':
         helm.deploy(

--- a/hubploy/__main__.py
+++ b/hubploy/__main__.py
@@ -1,7 +1,7 @@
 import argparse
 import hubploy
 import sys
-from hubploy import helm, auth, commitrange
+from hubploy import helm, auth, commitrange, utils
 
 
 def main():
@@ -118,8 +118,8 @@ def main():
             print(f"Images found: {len(build_images)}")
             for image in build_images:
                 if image.needs_building(check_registry=args.check_registry, commit_range=args.commit_range):
-                    print(f"Building image {image.name}")
                     image.build(not args.no_cache)
+                    utils.print_installed_packages(image.image_spec)
                     if args.push:
                         image.push()
                 else:


### PR DESCRIPTION
Our package installs install their own dependencies, and it
is very useful to know what all has been installed. This
prints list of installed packages right after they are built,
providing this info.