### PR TITLE
don't exit on image spec validation failure

### DIFF
--- a/hubploy/config.py
+++ b/hubploy/config.py
@@ -61,7 +61,9 @@ def validate_image_configs(config_files):
             continue
 
     if image_counter == 0:
-        raise RuntimeError(f"No image references found in config files: {config_files}")
+        logger.warning(
+            f"Hubploy isn't smart enough to parse images in these files.  Full speed ahead!  Pew Pew! {config_files}"
+        )
     else:
         logger.info(
             f"Found {image_counter} valid image reference(s) in config files: {config_files}"


### PR DESCRIPTION
the `cdss-discovery` image has a complex, fancy-profile config w/many (many) image specs.

hubploy is not quite as smart as it could (should?) be...  and it's easily confused and fails to deploy:

https://github.com/berkeley-dsep-infra/datahub/actions/runs/21966449272/job/63457429708

this change removes the `RuntimeError` and just spits out a pithy warning instead.
