### PR TITLE
pin kubernetes client to 35.0.0 to fix exec credential regression

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 ruamel-yaml
-kubernetes
+kubernetes==35.0.0
 boto3
 botocore


### PR DESCRIPTION
## Summary

- Pins `kubernetes==35.0.0` in `requirements.txt`
- `kubernetes 36.0.0` (released 2026-05-20) introduced a breaking change in exec-based credential handling in the Python client
- This causes hubploy's namespace existence check (`CoreV1Api().read_namespace()`) to authenticate as `system:anonymous` and fail with 403 Forbidden, even when `GOOGLE_APPLICATION_CREDENTIALS` is correctly set and `gcloud container clusters get-credentials` has succeeded
- Go-based tools (helm, kubectl) are unaffected; only the Python kubernetes client's exec credential subprocess invocation is broken

## Test plan

- [x] Install hubploy from this branch and run a hub deployment
- [x] Verify namespace check passes and helm deploy completes
- [ ] Unpin once the upstream regression is fixed in kubernetes 36.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)