### PR TITLE
adding a `--keyless` option for using WIF instead of encrypted gke keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,4 +55,43 @@ options:
   --cleanup-on-fail     Helm option: allow deletion of new resources created in this upgrade when upgrade fails.
   --dry-run             Dry run the helm upgrade command. This also renders the chart to STDOUT. This is not allowed to be used in a CI environment due to secrets being
                         displayed in plain text, and the script will exit. To enable this option, set a local environment varible HUBPLOY_LOCAL_DEBUG=true
+  --keyless             Authenticate with Application Default Credentials instead of the service_key in hubploy.yaml, which is ignored. Needs workload identity
+                        federation in CI, or 'gcloud auth application-default login' locally. gcloud provider only.
 ```
+
+## Keyless GCP authentication
+
+The `gcloud` provider normally decrypts the service account key named by
+`service_key` in `hubploy.yaml`, then activates it, which changes the machine's
+active gcloud login for the duration of the deploy.
+
+`--keyless` skips all of that. It mints a token from [Application Default
+Credentials][adc], reads the cluster endpoint and CA cert from the GKE API, and
+writes its own kubeconfig. No key, no gcloud, no global state to put back.
+
+[adc]: https://cloud.google.com/docs/authentication/application-default-credentials
+
+``` bash
+hubploy deploy --keyless <deployment> <chart> <environment>
+```
+
+In CI, authenticate with workload identity federation first:
+
+``` yaml
+- uses: google-github-actions/auth@v3
+  with:
+    workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
+    service_account: ${{ vars.DEPLOY_SA }}
+
+- run: hubploy deploy --keyless <deployment> hub prod
+```
+
+Locally, log in once:
+
+``` bash
+gcloud auth application-default login
+```
+
+`service_key` is ignored under `--keyless`, so one `hubploy.yaml` serves both
+paths and going back to the key means dropping the flag. Passing `--keyless`
+with a non-gcloud provider is an error.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ positional arguments:
 options:
   -h, --help        show this help message and exit
   -d, --debug       Enable tool debug output (not including helm debug).
-  -D, --helm-debug  Enable Helm debug output. This is not allowed to be used in a CI environment due to secrets being displayed in plain text, and the script will exit. To enable this option, set a local environment varible HUBPLOY_LOCAL_DEBUG=true
+  -D, --helm-debug  Enable Helm debug output. This is not allowed to be used in a CI environment due to secrets being displayed in plain text, and the script will exit. To enable this option, set a local environment variable HUBPLOY_LOCAL_DEBUG=true
   -v, --verbose     Enable verbose output.
 ```
 
@@ -54,7 +54,7 @@ options:
                         used.
   --cleanup-on-fail     Helm option: allow deletion of new resources created in this upgrade when upgrade fails.
   --dry-run             Dry run the helm upgrade command. This also renders the chart to STDOUT. This is not allowed to be used in a CI environment due to secrets being
-                        displayed in plain text, and the script will exit. To enable this option, set a local environment varible HUBPLOY_LOCAL_DEBUG=true
+                        displayed in plain text, and the script will exit. To enable this option, set a local environment variable HUBPLOY_LOCAL_DEBUG=true
   --keyless             Authenticate with Application Default Credentials instead of the service_key in hubploy.yaml, which is ignored. Needs workload identity
                         federation in CI, or 'gcloud auth application-default login' locally. gcloud provider only.
 ```

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Toolkit to deploy many z2jh based JupyterHubs
 
-`hubploy` is a thin wrapper around cloud provider authentication,
-configuration file parsing and `helm`.
+`hubploy` is a thin wrapper around cloud provider authentication, configuration
+file parsing and `helm`.
 
 Usage:
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Toolkit to deploy many z2jh based JupyterHubs
 
+`hubploy` is a thin wrapper around cloud provider authentication,
+configuration file parsing and `helm`.
+
 Usage:
 
 ``` bash

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Deploy help:
 ``` bash
 hubploy deploy --help
 usage: hubploy deploy [-h] [--namespace NAMESPACE] [--set SET] [--set-string SET_STRING] [--version VERSION] [--timeout TIMEOUT] [--force] [--atomic]
-                      [--cleanup-on-fail] [--dry-run] [--image-overrides IMAGE_OVERRIDES [IMAGE_OVERRIDES ...]]
+                      [--cleanup-on-fail] [--dry-run] [--encrypted-key]
                       deployment chart {develop,staging,prod}
 
 positional arguments:
@@ -46,36 +46,27 @@ options:
   --set SET             Helm option: set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
   --set-string SET_STRING
                         Helm option: set STRING values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
-  --version VERSION     Helm option: specify a version constraint for the chart version to use. This constraint can be a specific tag (e.g. 1.1.1) or it may reference a
-                        valid range (e.g. ^2.0.0). If this is not specified, the latest version is used.
+  --version VERSION     Helm option: specify a version constraint for the chart version to use. This constraint can be a specific tag (e.g. 1.1.1) or it may reference a valid range (e.g. ^2.0.0). If this is not specified, the latest version is used.
   --timeout TIMEOUT     Helm option: time in seconds to wait for any individual Kubernetes operation (like Jobs for hooks, etc). Defaults to 300 seconds.
   --force               Helm option: force resource updates through a replacement strategy.
-  --atomic              Helm option: if set, upgrade process rolls back changes made in case of failed upgrade. The --wait flag will be set automatically if --atomic is
-                        used.
+  --atomic              Helm option: if set, upgrade process rolls back changes made in case of failed upgrade. The --wait flag will be set automatically if --atomic is used.
   --cleanup-on-fail     Helm option: allow deletion of new resources created in this upgrade when upgrade fails.
-  --dry-run             Dry run the helm upgrade command. This also renders the chart to STDOUT. This is not allowed to be used in a CI environment due to secrets being
-                        displayed in plain text, and the script will exit. To enable this option, set a local environment variable HUBPLOY_LOCAL_DEBUG=true
-  --keyless             Authenticate with Application Default Credentials instead of the service_key in hubploy.yaml, which is ignored. Needs workload identity
-                        federation in CI, or 'gcloud auth application-default login' locally. gcloud provider only.
+  --dry-run             Dry run the helm upgrade command. This also renders the chart to STDOUT. This is not allowed to be used in a CI environment due to secrets being displayed in plain text, and the script will exit. To enable this option, set a local environment variable HUBPLOY_LOCAL_DEBUG=true
+  --encrypted-key, -K   Use an encrypted service account key for GCP authentication. This is defined as service_key in hubploy.yaml. If this is not specified, the default GCP credentials will be used.
 ```
 
-## Keyless GCP authentication
+## Authentication
 
-The `gcloud` provider normally decrypts the service account key named by
-`service_key` in `hubploy.yaml`, then activates it, which changes the machine's
-active gcloud login for the duration of the deploy.
+### GCP
 
-`--keyless` skips all of that. It mints a token from [Application Default
-Credentials][adc], reads the cluster endpoint and CA cert from the GKE API, and
-writes its own kubeconfig. No key, no gcloud, no global state to put back.
+#### Keyless
 
-[adc]: https://cloud.google.com/docs/authentication/application-default-credentials
+For logging in to GCP, `hubploy` mints a short-lived token from [Application
+Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials),
+reads the cluster endpoint and CA cert from the GKE API, and writes its own
+kubeconfig.
 
-``` bash
-hubploy deploy --keyless <deployment> <chart> <environment>
-```
-
-In CI, authenticate with workload identity federation first:
+In CI/CD, authenticate with workload identity federation first:
 
 ``` yaml
 - uses: google-github-actions/auth@v3
@@ -83,15 +74,44 @@ In CI, authenticate with workload identity federation first:
     workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
     service_account: ${{ vars.DEPLOY_SA }}
 
-- run: hubploy deploy --keyless <deployment> hub prod
+- run: hubploy deploy <deployment> <hub chart> <environment>
 ```
 
-Locally, log in once:
+For local deploy runs, be sure you're logged in:
 
 ``` bash
 gcloud auth application-default login
 ```
 
-`service_key` is ignored under `--keyless`, so one `hubploy.yaml` serves both
-paths and going back to the key means dropping the flag. Passing `--keyless`
-with a non-gcloud provider is an error.
+Note:  If you happen to have encrypted keys defined in `hubploy.yaml`, they will
+be ignored by default.
+
+#### Encrypted Keys
+
+If you want to use encrypted keys on disk, the `gcloud` provider will decrypt
+the service account key named by `service_key` in `hubploy.yaml`. The service
+account is then activated, which changes the machine's active gcloud login for
+the duration of the deploy.
+
+To use encrypted key authentication, pass the `--encrypted-key/-K` flags after
+`deploy` on the CLI.
+
+``` bash
+hubploy deploy -K <deployment> <hub chart> <environment>
+```
+
+### AWS
+
+Currently, you can use either the AWS environment variables or an encrypted key.
+
+For the environment variables, ensure that the following are present and current:
+
+``` bash
+AWS_ACCESS_KEY_ID
+AWS_SECRET_ACCESS_KEY
+AWS_SESSION_TOKEN
+```
+
+### Azure
+
+Azure authentication is handled purely with an encrypted file.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,9 @@
-ruamel-yaml
-kubernetes
 boto3
 botocore
+codecov
+google-auth
+kubernetes
 pytest
 pytest-cov
-codecov
+requests
+ruamel-yaml

--- a/hubploy/__main__.py
+++ b/hubploy/__main__.py
@@ -28,7 +28,7 @@ def main():
         help="Enable Helm debug output. This is not allowed to be used in a "
         + "CI environment due to secrets being displayed in plain text, and "
         + "the script will exit. To enable this option, set a local environment "
-        + "varible HUBPLOY_LOCAL_DEBUG=true",
+        + "variable HUBPLOY_LOCAL_DEBUG=true",
     )
     argparser.add_argument(
         "-v", "--verbose", action="store_true", help="Enable verbose output."
@@ -102,7 +102,7 @@ def main():
         + "chart to STDOUT. This is not allowed to be used in a "
         + "CI environment due to secrets being displayed in plain text, and "
         + "the script will exit. To enable this option, set a local environment "
-        + "varible HUBPLOY_LOCAL_DEBUG=true",
+        + "variable HUBPLOY_LOCAL_DEBUG=true",
     )
     deploy_parser.add_argument(
         "--keyless",

--- a/hubploy/__main__.py
+++ b/hubploy/__main__.py
@@ -104,6 +104,15 @@ def main():
         + "the script will exit. To enable this option, set a local environment "
         + "varible HUBPLOY_LOCAL_DEBUG=true",
     )
+    deploy_parser.add_argument(
+        "--keyless",
+        default=False,
+        action="store_true",
+        help="Authenticate with Application Default Credentials instead of the "
+        + "service_key in hubploy.yaml, which is ignored. Needs workload "
+        + "identity federation in CI, or 'gcloud auth application-default "
+        + "login' locally. gcloud provider only.",
+    )
 
     args = argparser.parse_args()
 
@@ -165,6 +174,7 @@ def main():
         args.verbose,
         args.helm_debug,
         args.dry_run,
+        args.keyless,
     )
 
 

--- a/hubploy/__main__.py
+++ b/hubploy/__main__.py
@@ -105,13 +105,13 @@ def main():
         + "variable HUBPLOY_LOCAL_DEBUG=true",
     )
     deploy_parser.add_argument(
-        "--keyless",
+        "--encrypted-key",
+        "-K",
         default=False,
         action="store_true",
-        help="Authenticate with Application Default Credentials instead of the "
-        + "service_key in hubploy.yaml, which is ignored. Needs workload "
-        + "identity federation in CI, or 'gcloud auth application-default "
-        + "login' locally. gcloud provider only.",
+        help="Use an encrypted service account key for GCP authentication. "
+        + "This is defined as service_key in hubploy.yaml. If this is not "
+        + "specified, the default GCP credentials will be used.",
     )
 
     args = argparser.parse_args()
@@ -174,7 +174,7 @@ def main():
         args.verbose,
         args.helm_debug,
         args.dry_run,
-        args.keyless,
+        args.encrypted_key,
     )
 
 

--- a/hubploy/auth.py
+++ b/hubploy/auth.py
@@ -159,8 +159,8 @@ def cluster_auth_gcloud_keyless(deployment, project, cluster, zone, service_key=
 
     Unlike cluster_auth_gcloud, this needs no service account key, never shells
     out to gcloud, and leaves global machine state alone: it mints a token from
-    whatever ambient credential ADC finds, reads the cluster's endpoint and CA
-    from the GKE API, and writes a self-contained kubeconfig.
+    ADC, reads the cluster's endpoint and CA from the GKE API, and writes the
+    self-contained kubeconfig.
 
     service_key is accepted and ignored so that one hubploy.yaml can serve both
     the keyed and keyless paths.

--- a/hubploy/auth.py
+++ b/hubploy/auth.py
@@ -30,7 +30,7 @@ CLOUD_PLATFORM_SCOPE = "https://www.googleapis.com/auth/cloud-platform"
 
 
 @contextmanager
-def cluster_auth(deployment, debug=False, verbose=False, keyless=False):
+def cluster_auth(deployment, debug=False, verbose=False, encrypted_key=False):
     """
     Do appropriate cluster authentication for given deployment
     """
@@ -46,12 +46,6 @@ def cluster_auth(deployment, debug=False, verbose=False, keyless=False):
         cluster = config["cluster"]
         provider = cluster.get("provider")
         orig_kubeconfig = os.environ.get("KUBECONFIG", None)
-
-        if keyless and provider != "gcloud":
-            raise ValueError(
-                f"--keyless is only supported for the gcloud provider, "
-                f"but hubploy.yaml sets provider: {provider}"
-            )
 
         try:
             if provider == "kubeconfig":
@@ -79,12 +73,12 @@ def cluster_auth(deployment, debug=False, verbose=False, keyless=False):
                     logger.info(f"Attempting to authenticate with {provider}...")
 
                     if provider == "gcloud":
-                        if keyless:
-                            yield from cluster_auth_gcloud_keyless(
+                        if encrypted_key:
+                            yield from cluster_auth_gcloud(
                                 deployment, **cluster["gcloud"]
                             )
                         else:
-                            yield from cluster_auth_gcloud(
+                            yield from cluster_auth_gcloud_keyless(
                                 deployment, **cluster["gcloud"]
                             )
                     elif provider == "aws":
@@ -171,14 +165,14 @@ def cluster_auth_gcloud_keyless(deployment, project, cluster, zone, service_key=
     if service_key:
         logger.info(
             f"Ignoring service_key {service_key} from hubploy.yaml: "
-            + "--keyless authenticates with Application Default Credentials"
+            + "keyless authenticates with Application Default Credentials"
         )
 
     try:
         credentials, adc_project = google.auth.default(scopes=[CLOUD_PLATFORM_SCOPE])
     except DefaultCredentialsError as e:
         raise DefaultCredentialsError(
-            "--keyless found no Application Default Credentials. In CI, "
+            "Hubploy found no Application Default Credentials. In CI, "
             "authenticate with workload identity federation first. Locally, run "
             "`gcloud auth application-default login`."
         ) from e

--- a/hubploy/auth.py
+++ b/hubploy/auth.py
@@ -190,12 +190,23 @@ def cluster_auth_gcloud_keyless(deployment, project, cluster, zone, service_key=
         headers={"Authorization": f"Bearer {credentials.token}"},
         timeout=30,
     )
-    response.raise_for_status()
+    try:
+        response.raise_for_status()
+    except requests.HTTPError:
+        logger.error(f"GKE API returned {response.status_code}: {response.text}")
+        raise
     cluster_info = response.json()
+
+    kubeconfig_path = os.environ.get("KUBECONFIG")
+    if not kubeconfig_path:
+        raise RuntimeError(
+            "KUBECONFIG is not set; cluster_auth_gcloud_keyless expects to run "
+            "inside cluster_auth, which creates the temporary kubeconfig."
+        )
 
     context = f"gke_{project}_{zone}_{cluster}"
     write_gke_kubeconfig(
-        os.environ["KUBECONFIG"],
+        kubeconfig_path,
         context,
         cluster_info["endpoint"],
         cluster_info["masterAuth"]["clusterCaCertificate"],
@@ -203,7 +214,6 @@ def cluster_auth_gcloud_keyless(deployment, project, cluster, zone, service_key=
     )
     logger.info(f"Wrote a kubeconfig for context {context}")
 
-    # Nothing to revert: no gcloud login was ever changed.
     yield None
 
 

--- a/hubploy/auth.py
+++ b/hubploy/auth.py
@@ -7,13 +7,17 @@ Current cloud providers supported: gcloud, aws, and azure.
 """
 
 import boto3
+import google.auth
 import json
 import logging
 import os
+import requests
 import subprocess
 import tempfile
 
 from contextlib import contextmanager
+from google.auth.exceptions import DefaultCredentialsError
+from google.auth.transport.requests import Request
 from hubploy.config import get_config
 from ruamel.yaml import YAML
 from ruamel.yaml.scanner import ScannerError
@@ -21,9 +25,12 @@ from ruamel.yaml.scanner import ScannerError
 logger = logging.getLogger(__name__)
 yaml = YAML(typ="rt")
 
+GKE_API = "https://container.googleapis.com/v1"
+CLOUD_PLATFORM_SCOPE = "https://www.googleapis.com/auth/cloud-platform"
+
 
 @contextmanager
-def cluster_auth(deployment, debug=False, verbose=False):
+def cluster_auth(deployment, debug=False, verbose=False, keyless=False):
     """
     Do appropriate cluster authentication for given deployment
     """
@@ -39,6 +46,12 @@ def cluster_auth(deployment, debug=False, verbose=False):
         cluster = config["cluster"]
         provider = cluster.get("provider")
         orig_kubeconfig = os.environ.get("KUBECONFIG", None)
+
+        if keyless and provider != "gcloud":
+            raise ValueError(
+                f"--keyless is only supported for the gcloud provider, "
+                f"but hubploy.yaml sets provider: {provider}"
+            )
 
         try:
             if provider == "kubeconfig":
@@ -65,7 +78,11 @@ def cluster_auth(deployment, debug=False, verbose=False):
                     os.environ["KUBECONFIG"] = temp_kubeconfig.name
                     logger.info(f"Attempting to authenticate with {provider}...")
 
-                    if provider == "gcloud":
+                    if provider == "gcloud" and keyless:
+                        yield from cluster_auth_gcloud_keyless(
+                            deployment, **cluster["gcloud"]
+                        )
+                    elif provider == "gcloud":
                         yield from cluster_auth_gcloud(deployment, **cluster["gcloud"])
                     elif provider == "aws":
                         yield from cluster_auth_aws(deployment, **cluster["aws"])
@@ -134,6 +151,99 @@ def cluster_auth_gcloud(deployment, project, cluster, zone, service_key):
     subprocess.check_call(gcloud_cluster_credential_command)
 
     yield current_login
+
+
+def cluster_auth_gcloud_keyless(deployment, project, cluster, zone, service_key=None):
+    """
+    Setup GKE authentication with Application Default Credentials
+
+    Unlike cluster_auth_gcloud, this needs no service account key, never shells
+    out to gcloud, and leaves global machine state alone: it mints a token from
+    whatever ambient credential ADC finds, reads the cluster's endpoint and CA
+    from the GKE API, and writes a self-contained kubeconfig.
+
+    ADC resolves to a workload identity federation credentials file in CI (the
+    one google-github-actions/auth writes), or to the user's own credentials
+    from `gcloud auth application-default login` when run locally.
+
+    service_key is accepted and ignored so that one hubploy.yaml can serve both
+    the keyed and keyless paths.
+    """
+    if service_key:
+        logger.info(
+            f"Ignoring service_key {service_key} from hubploy.yaml: "
+            + "--keyless authenticates with Application Default Credentials"
+        )
+
+    try:
+        credentials, adc_project = google.auth.default(scopes=[CLOUD_PLATFORM_SCOPE])
+    except DefaultCredentialsError as e:
+        raise DefaultCredentialsError(
+            "--keyless found no Application Default Credentials. In CI, "
+            "authenticate with workload identity federation first. Locally, run "
+            "`gcloud auth application-default login`."
+        ) from e
+
+    logger.info(f"Found Application Default Credentials for project {adc_project}")
+    credentials.refresh(Request())
+
+    # A zonal and a regional cluster differ only in the location string, which
+    # the GKE API takes either way.
+    url = f"{GKE_API}/projects/{project}/locations/{zone}/clusters/{cluster}"
+    logger.info(f"Getting credentials for {cluster} in {zone}")
+    logger.debug(f"Querying the GKE API: {url}")
+    response = requests.get(
+        url,
+        headers={"Authorization": f"Bearer {credentials.token}"},
+        timeout=30,
+    )
+    response.raise_for_status()
+    cluster_info = response.json()
+
+    context = f"gke_{project}_{zone}_{cluster}"
+    write_gke_kubeconfig(
+        os.environ["KUBECONFIG"],
+        context,
+        cluster_info["endpoint"],
+        cluster_info["masterAuth"]["clusterCaCertificate"],
+        credentials.token,
+    )
+    logger.info(f"Wrote a kubeconfig for context {context}")
+
+    # Nothing to revert: no gcloud login was ever changed.
+    yield None
+
+
+def write_gke_kubeconfig(path, context, endpoint, ca_cert, token):
+    """
+    Write a single-context kubeconfig that authenticates with a bearer token
+
+    The token is short lived, and it is the whole credential, so this file is
+    written to the caller's temporary KUBECONFIG and never logged.
+    """
+    kubeconfig = {
+        "apiVersion": "v1",
+        "kind": "Config",
+        "current-context": context,
+        "clusters": [
+            {
+                "name": context,
+                "cluster": {
+                    "server": f"https://{endpoint}",
+                    "certificate-authority-data": ca_cert,
+                },
+            }
+        ],
+        "contexts": [
+            {
+                "name": context,
+                "context": {"cluster": context, "user": context},
+            }
+        ],
+        "users": [{"name": context, "user": {"token": token}}],
+    }
+    with open(path, "w") as f:
+        yaml.dump(kubeconfig, f)
 
 
 @contextmanager

--- a/hubploy/auth.py
+++ b/hubploy/auth.py
@@ -78,12 +78,15 @@ def cluster_auth(deployment, debug=False, verbose=False, keyless=False):
                     os.environ["KUBECONFIG"] = temp_kubeconfig.name
                     logger.info(f"Attempting to authenticate with {provider}...")
 
-                    if provider == "gcloud" and keyless:
-                        yield from cluster_auth_gcloud_keyless(
-                            deployment, **cluster["gcloud"]
-                        )
-                    elif provider == "gcloud":
-                        yield from cluster_auth_gcloud(deployment, **cluster["gcloud"])
+                    if provider == "gcloud":
+                        if keyless:
+                            yield from cluster_auth_gcloud_keyless(
+                                deployment, **cluster["gcloud"]
+                            )
+                        else:
+                            yield from cluster_auth_gcloud(
+                                deployment, **cluster["gcloud"]
+                            )
                     elif provider == "aws":
                         yield from cluster_auth_aws(deployment, **cluster["aws"])
                     elif provider == "azure":

--- a/hubploy/auth.py
+++ b/hubploy/auth.py
@@ -162,10 +162,6 @@ def cluster_auth_gcloud_keyless(deployment, project, cluster, zone, service_key=
     whatever ambient credential ADC finds, reads the cluster's endpoint and CA
     from the GKE API, and writes a self-contained kubeconfig.
 
-    ADC resolves to a workload identity federation credentials file in CI (the
-    one google-github-actions/auth writes), or to the user's own credentials
-    from `gcloud auth application-default login` when run locally.
-
     service_key is accepted and ignored so that one hubploy.yaml can serve both
     the keyed and keyless paths.
     """

--- a/hubploy/helm.py
+++ b/hubploy/helm.py
@@ -140,6 +140,7 @@ def deploy(
     verbose=False,
     helm_debug=False,
     dry_run=False,
+    keyless=False,
 ):
     """
     Deploy a JupyterHub.
@@ -222,13 +223,16 @@ def deploy(
             "Activating cluster credentials for deployment "
             + f"{deployment} and performing deployment upgrade."
         )
+        # Only the keyed gcloud path changes the machine's active login, so it
+        # is the only one with anything to revert.
         provider = config.get("cluster", {}).get("provider")
-        if provider == "gcloud":
+        gcloud_key_auth = provider == "gcloud" and not keyless
+        if gcloud_key_auth:
             current_login = stack.enter_context(
-                cluster_auth(deployment, debug, verbose)
+                cluster_auth(deployment, debug, verbose, keyless)
             )
         else:
-            stack.enter_context(cluster_auth(deployment, debug, verbose))
+            stack.enter_context(cluster_auth(deployment, debug, verbose, keyless))
         helm_upgrade(
             name,
             namespace,
@@ -248,5 +252,5 @@ def deploy(
             dry_run,
         )
         # Revert the gcloud auth
-        if provider == "gcloud":
+        if gcloud_key_auth:
             stack.enter_context(revert_gcloud_auth(current_login))

--- a/hubploy/helm.py
+++ b/hubploy/helm.py
@@ -223,16 +223,11 @@ def deploy(
             "Activating cluster credentials for deployment "
             + f"{deployment} and performing deployment upgrade."
         )
-        # Only the keyed gcloud path changes the machine's active login, so it
-        # is the only one with anything to revert.
         provider = config.get("cluster", {}).get("provider")
         gcloud_key_auth = provider == "gcloud" and encrypted_key
-        if gcloud_key_auth:
-            current_login = stack.enter_context(
-                cluster_auth(deployment, debug, verbose, encrypted_key)
-            )
-        else:
-            stack.enter_context(cluster_auth(deployment, debug, verbose, encrypted_key))
+        current_login = stack.enter_context(
+            cluster_auth(deployment, debug, verbose, encrypted_key)
+        )
         helm_upgrade(
             name,
             namespace,

--- a/hubploy/helm.py
+++ b/hubploy/helm.py
@@ -140,7 +140,7 @@ def deploy(
     verbose=False,
     helm_debug=False,
     dry_run=False,
-    keyless=False,
+    encrypted_key=False,
 ):
     """
     Deploy a JupyterHub.
@@ -226,13 +226,13 @@ def deploy(
         # Only the keyed gcloud path changes the machine's active login, so it
         # is the only one with anything to revert.
         provider = config.get("cluster", {}).get("provider")
-        gcloud_key_auth = provider == "gcloud" and not keyless
+        gcloud_key_auth = provider == "gcloud" and encrypted_key
         if gcloud_key_auth:
             current_login = stack.enter_context(
-                cluster_auth(deployment, debug, verbose, keyless)
+                cluster_auth(deployment, debug, verbose, encrypted_key)
             )
         else:
-            stack.enter_context(cluster_auth(deployment, debug, verbose, keyless))
+            stack.enter_context(cluster_auth(deployment, debug, verbose, encrypted_key))
         helm_upgrade(
             name,
             namespace,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "hubploy"
 description = "A tool for deploying Zero to Jupyterhub Helm charts."
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "1.0.0"
+version = "1.0.1"
 requires-python = ">=3.10"
 dynamic = ["dependencies", "optional-dependencies"]
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "hubploy"
 description = "A tool for deploying Zero to Jupyterhub Helm charts."
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "1.0.1"
+version = "1.1.0"
 requires-python = ">=3.10"
 dynamic = ["dependencies", "optional-dependencies"]
 authors = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
-ruamel-yaml
-kubernetes==35.0.0
 boto3
 botocore
+google-auth
+kubernetes==35.0.0
+requests
+ruamel-yaml


### PR DESCRIPTION
since i'm moving my builds away from the shared/encrypted gke key to WIF, add an option to support this.

instead of shelling out to `gcloud` and activating the service account, this just uses the application default credentials from the user account or perms inherited from a deploy-based service account.  the biggest win is that we will no longer need to store encrypted deployment keys in our repo!

the main reason i'm sticking w/hubploy and not just moving my CI/CD and local deploys to pure helm is simple:  i don't want to need to type out or copy-paste long helm commands.  hubploy is becoming more of just a thin wrapper around helm rather than a 'do tons of stuff' tool.

i've tested this locally w/both keyed and keyless deploys and everything worked as intended.

keyless:

```
(dh) ➜  cal-icor-hubs git:(staging) hubploy -v deploy jupyter hub staging --keyless
INFO:hubploy.__main__:Namespace(command='deploy', debug=False, helm_debug=False, verbose=True, deployment='jupyter', chart='hub', environment='staging', namespace=None, set=None, set_string=None, version=None, timeout=None, force=False, atomic=False, cleanup_on_fail=False, dry_run=False, keyless=True)
INFO:hubploy.helm:Deploying jupyter to staging
INFO:hubploy.helm:Getting image and deployment config for jupyter
INFO:hubploy.config:Loading hubploy config from /home/sknapp/src/calicor/cal-icor-hubs/deployments/jupyter/hubploy.yaml
INFO:hubploy.config:Found 1 valid image reference(s) in config files: ['deployments/jupyter/config/common.yaml', 'deployments/jupyter/config/staging.yaml']
INFO:hubploy.auth:Getting auth config for jupyter
INFO:hubploy.config:Loading hubploy config from /home/sknapp/src/calicor/cal-icor-hubs/deployments/jupyter/hubploy.yaml
INFO:hubploy.auth:Attempting to authenticate with gcloud...
INFO:hubploy.auth:Ignoring service_key gke-key.json from hubploy.yaml: --keyless authenticates with Application Default Credentials
INFO:hubploy.auth:Found Application Default Credentials for project cal-icor-hubs
INFO:hubploy.auth:Getting credentials for spring-2025 in us-central1
INFO:hubploy.auth:Wrote a kubeconfig for context gke_cal-icor-hubs_us-central1_spring-2025
INFO:hubploy.helm:Deploying jupyter-staging in namespace jupyter-staging
Getting updates for unmanaged Helm repositories...
...Successfully got an update from the "https://jupyterhub.github.io/helm-chart/" chart repository
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "autoscaler" chart repository
...Successfully got an update from the "jetstack" chart repository
...Successfully got an update from the "jupyterhub" chart repository
...Successfully got an update from the "grafana" chart repository
...Successfully got an update from the "prometheus-community" chart repository
Update Complete. ⎈Happy Helming!⎈
Saving 1 charts
Downloading jupyterhub from repo https://jupyterhub.github.io/helm-chart/
Deleting outdated charts
INFO:hubploy.helm:Loaded kubeconfig /tmp/tmpfil5t_b7 for context None
INFO:hubploy.helm:Running helm upgrade on jupyter-staging.
Release "jupyter-staging" has been upgraded. Happy Helming!
NAME: jupyter-staging
LAST DEPLOYED: Tue Jul 14 12:39:06 2026
NAMESPACE: jupyter-staging
STATUS: deployed
REVISION: 349
TEST SUITE: None
```

same exact `hubploy.yaml`, except this time w/the key:

```
(dh) ➜  cal-icor-hubs git:(staging) hubploy -v deploy jupyter hub staging
INFO:hubploy.__main__:Namespace(command='deploy', debug=False, helm_debug=False, verbose=True, deployment='jupyter', chart='hub', environment='staging', namespace=None, set=None, set_string=None, version=None, timeout=None, force=False, atomic=False, cleanup_on_fail=False, dry_run=False, keyless=False)
INFO:hubploy.helm:Deploying jupyter to staging
INFO:hubploy.helm:Getting image and deployment config for jupyter
INFO:hubploy.config:Loading hubploy config from /home/sknapp/src/calicor/cal-icor-hubs/deployments/jupyter/hubploy.yaml
INFO:hubploy.config:Found 1 valid image reference(s) in config files: ['deployments/jupyter/config/common.yaml', 'deployments/jupyter/config/staging.yaml']
INFO:hubploy.auth:Getting auth config for jupyter
INFO:hubploy.config:Loading hubploy config from /home/sknapp/src/calicor/cal-icor-hubs/deployments/jupyter/hubploy.yaml
INFO:hubploy.auth:Attempting to authenticate with gcloud...
INFO:hubploy.auth:Saving current gcloud login
INFO:hubploy.auth:Current gcloud login: sknapp@berkeley.edu
INFO:hubploy.auth:Decrypting deployments/jupyter/secrets/gke-key.json
INFO:hubploy.auth:File is sops encrypted, decrypting...
INFO:hubploy.auth:Activating service account for cal-icor-hubs
Activated service account credentials for: [hubploy-922@cal-icor-hubs.iam.gserviceaccount.com]
INFO:hubploy.auth:Getting credentials for spring-2025 in us-central1
Fetching cluster endpoint and auth data.
kubeconfig entry generated for spring-2025.
INFO:hubploy.helm:Deploying jupyter-staging in namespace jupyter-staging
Getting updates for unmanaged Helm repositories...
...Successfully got an update from the "https://jupyterhub.github.io/helm-chart/" chart repository
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "autoscaler" chart repository
...Successfully got an update from the "jetstack" chart repository
...Successfully got an update from the "jupyterhub" chart repository
...Successfully got an update from the "grafana" chart repository
...Successfully got an update from the "prometheus-community" chart repository
Update Complete. ⎈Happy Helming!⎈
Saving 1 charts
Downloading jupyterhub from repo https://jupyterhub.github.io/helm-chart/
Deleting outdated charts
INFO:hubploy.helm:Loaded kubeconfig /tmp/tmp64yevhn_ for context None
INFO:hubploy.helm:Running helm upgrade on jupyter-staging.
Release "jupyter-staging" has been upgraded. Happy Helming!
NAME: jupyter-staging
LAST DEPLOYED: Tue Jul 14 12:40:09 2026
NAMESPACE: jupyter-staging
STATUS: deployed
REVISION: 350
TEST SUITE: None
INFO:hubploy.auth:Reverting gcloud login to sknapp@berkeley.edu
Updated property [core/account].
```