### PR TITLE
add email scope to auth

### DIFF
--- a/hubploy/auth.py
+++ b/hubploy/auth.py
@@ -27,6 +27,10 @@ yaml = YAML(typ="rt")
 
 GKE_API = "https://container.googleapis.com/v1"
 CLOUD_PLATFORM_SCOPE = "https://www.googleapis.com/auth/cloud-platform"
+# Without this scope the token carries no email claim, so GKE resolves the
+# caller to the service account's numeric uniqueId instead of its email and
+# email-based RBAC bindings do not match.
+USERINFO_EMAIL_SCOPE = "https://www.googleapis.com/auth/userinfo.email"
 
 
 @contextmanager
@@ -169,7 +173,9 @@ def cluster_auth_gcloud_keyless(deployment, project, cluster, zone, service_key=
         )
 
     try:
-        credentials, adc_project = google.auth.default(scopes=[CLOUD_PLATFORM_SCOPE])
+        credentials, adc_project = google.auth.default(
+            scopes=[CLOUD_PLATFORM_SCOPE, USERINFO_EMAIL_SCOPE]
+        )
     except DefaultCredentialsError as e:
         raise DefaultCredentialsError(
             "Hubploy found no Application Default Credentials. In CI, "


### PR DESCRIPTION
turns out there's a small edge-case that didn't pop up until i tried a hub deploy in CI/CD:

```
HTTP response headers: HTTPHeaderDict({'audit-id': 'fe829452-1cd6-4eb9-ac95-b414eeb91c4a', 'cache-control': 'no-cache, private', 'content-type': 'application/json', 'x-content-type-options': 'nosniff', 'x-kubernetes-pf-flowschema-uid': '091be81c-baa1-46f0-bf66-210ada4b5cdc', 'x-kubernetes-pf-prioritylevel-uid': 'a88342fc-93cd-471c-84ea-3360b340015f', 'content-length': '475', 'date': 'Thu, 16 Jul 2026 19:16:00 GMT'})
HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"namespaces \"jupyter-prod\" is forbidden: User \"113346511983242004366\" cannot get resource \"namespaces\" in API group \"\" in the namespace \"jupyter-prod\": requires one of [\"container.namespaces.get\"] permission(s) in Cloud IAM or a Kubernetes RBAC role with verb \"get\" for resource \"namespaces\".","reason":"Forbidden","details":{"name":"jupyter-prod","kind":"namespaces"},"code":403}
```

this means that GKE can't get the email of the deployment SA, and revert to the unique ID.  this will allow hubploy to grab email scopes.

i will, again, test this locally and see if i find any other issues.  i firmly believe that this will fix things.