### PR TITLE
adding yijun to the pyproject def, also bumping version therein

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,16 +7,18 @@ name = "hubploy"
 description = "A tool for deploying Zero to Jupyterhub Helm charts."
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "1.1.0"
+version = "v1.2"
 requires-python = ">=3.10"
 dynamic = ["dependencies", "optional-dependencies"]
 authors = [
-    { name = "Yuvi Panda", email = "yuvipanda@gmail.com" },
     { name = "Shane Knapp", email = "sknapp@berkeley.edu" },
+    { name = "Yijun Ge", email = "yijunge@berkeley.edu" },
+    { name = "Yuvi Panda", email = "yuvipanda@gmail.com" },
 ]
 maintainers = [
-    { name = "Yuvi Panda", email = "yuvipanda@gmail.com" },
     { name = "Shane Knapp", email = "sknapp@berkeley.edu" },
+    { name = "Yijun Ge", email = "yijunge@berkeley.edu" },
+    { name = "Yuvi Panda", email = "yuvipanda@gmail.com" },
 ]
 
 [tool.hatch.metadata.hooks.requirements_txt]


### PR DESCRIPTION
minor nitpick:  i almost panicked when i was confirming that the latest hubploy was being installed on my github action runners and saw this:

```
Building wheels for collected packages: hubploy
  Building wheel for hubploy (pyproject.toml): started
  Building wheel for hubploy (pyproject.toml): finished with status 'done'
  Created wheel for hubploy: filename=hubploy-1.1.0-py3-none-any.whl size=13858 sha256=e2a50d1afbf720f3e1488d713351514a3264c34feb5b3dcbf60e523366b2faa2
```

then i scrolled up a bit and saw that yes, it was the proper version:

```
Collecting git+https://github.com/berkeley-dsep-infra/hubploy.git@v1.2 (from -r requirements.txt (line 4))
  Cloning https://github.com/berkeley-dsep-infra/hubploy.git (to revision v1.2) to /tmp/pip-req-build-bsk7f0sv
  Running command git clone --filter=blob:none --quiet https://github.com/berkeley-dsep-infra/hubploy.git /tmp/pip-req-build-bsk7f0sv
```

turns out, you need to bump the version in `pyproject.toml` as well!  XD

and, since i was in there, i figured i'd just add @yijunge-ucb to the authors/maintainers.  ;)